### PR TITLE
Base structure for Native Operators

### DIFF
--- a/examples/julia-softmax.jl
+++ b/examples/julia-softmax.jl
@@ -46,9 +46,7 @@ fc3 = mx.FullyConnected(data = act2, name="fc3", num_hidden=10)
 
 # Setup Native operator
 mysoftmax = JuliaSoftmax()
-info = mx.Native.NDArrayOpInfo(mysoftmax)
-pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
-mlp = mx._NDArray(name = "softmax", info = pstring, data=fc3)
+mlp = mysoftmax(name = "softmax", data=fc3)
 
 model = mx.FeedForward(mlp, context = mx.cpu())
 optimizer = mx.SGD(lr = 0.1, momentum = 0.9, weight_decay = 0.00001)

--- a/examples/julia-softmax.jl
+++ b/examples/julia-softmax.jl
@@ -1,8 +1,10 @@
 using MXNet
 
 import MXNet.mx.Native: Operator, list_arguments, list_outputs, infer_shape,
-                        forward, backward, need_top_grad
+                        forward, backward, need_top_grad, create_op
 type JuliaSoftmax <: Operator end
+
+(op::JuliaSoftmax)(;kwargs...) = create_op(op;kwargs...)
 
 list_arguments(:: JuliaSoftmax) = ["data", "label"]
 list_outputs(:: JuliaSoftmax) = ["output"]
@@ -16,6 +18,7 @@ function infer_shape(::JuliaSoftmax, in_shapes :: Vector{Vector{UInt32}})
 end
 
 function forward(::JuliaSoftmax, in_data :: Vector{mx.NDArray}, out_data :: Vector{mx.NDArray})
+  info("Entering forward")
   x = in_data[1]
   y = out_data[1]
 
@@ -23,10 +26,12 @@ function forward(::JuliaSoftmax, in_data :: Vector{mx.NDArray}, out_data :: Vect
     y[:] = exp(x - maximum(x, 1))
     y /= sum(y, 1)
   end
+  info("Leaving forward")
 end
 
 #TODO: Correct gradient
 function backward(::JuliaSoftmax, out_grad :: Vector{mx.NDArray}, in_data :: Vector{mx.NDArray}, out_data :: Vector{mx.NDArray}, in_grad :: Vector{mx.NDArray})
+  info("Entering backward")
   label = in_data[2]
   y = out_data[1]
   dx = in_grad[1]
@@ -34,6 +39,7 @@ function backward(::JuliaSoftmax, out_grad :: Vector{mx.NDArray}, in_data :: Vec
   @mx.nd_as_jl ro=(label, y) rw=dx begin
     dx[:] = y
   end
+  info("Leaving backward")
 end
 
 #define mlp

--- a/examples/julia-softmax.jl
+++ b/examples/julia-softmax.jl
@@ -10,9 +10,9 @@ need_top_grad(:: JuliaSoftmax) = false
 
 function infer_shape(::JuliaSoftmax, in_shape)
   data_shape = in_shape[1]
-  label_shape = (in_shape[1][1],)
+  label_shape = [in_shape[1][1]]
   output_shape = in_shape[1]
-  return [data_shape, label_shape], [output_shape]
+  return (data_shape, label_shape), (output_shape, )
 end
 
 function forward(::JuliaSoftmax, in_data, out_data)
@@ -48,7 +48,7 @@ fc3 = mx.FullyConnected(data = act2, name="fc3", num_hidden=10)
 mysoftmax = JuliaSoftmax()
 info = mx.Native.NDArrayOpInfo(mysoftmax)
 pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
-mlp = mx._Native(name = "softmax", info = pstring, data=fc3)
+mlp = mx._NDArray(name = "softmax", info = pstring, data=fc3)
 
 model = mx.FeedForward(mlp, context = mx.cpu())
 optimizer = mx.SGD(lr = 0.1, momentum = 0.9, weight_decay = 0.00001)

--- a/examples/julia-softmax.jl
+++ b/examples/julia-softmax.jl
@@ -8,14 +8,14 @@ list_arguments(:: JuliaSoftmax) = ["data", "label"]
 list_outputs(:: JuliaSoftmax) = ["output"]
 need_top_grad(:: JuliaSoftmax) = false
 
-function infer_shape(::JuliaSoftmax, in_shape)
-  data_shape = in_shape[1]
-  label_shape = [in_shape[1][1]]
-  output_shape = in_shape[1]
+function infer_shape(::JuliaSoftmax, in_shapes :: Vector{Vector{UInt32}})
+  data_shape = in_shapes[1]
+  label_shape = [last(data_shape)]
+  output_shape = data_shape
   return (data_shape, label_shape), (output_shape, )
 end
 
-function forward(::JuliaSoftmax, in_data, out_data)
+function forward(::JuliaSoftmax, in_data :: Vector{mx.NDArray}, out_data :: Vector{mx.NDArray})
   x = in_data[1]
   y = out_data[1]
 
@@ -26,7 +26,7 @@ function forward(::JuliaSoftmax, in_data, out_data)
 end
 
 #TODO: Correct gradient
-function backward(::JuliaSoftmax, out_grad, in_data, out_data, in_grad)
+function backward(::JuliaSoftmax, out_grad :: Vector{mx.NDArray}, in_data :: Vector{mx.NDArray}, out_data :: Vector{mx.NDArray}, in_grad :: Vector{mx.NDArray})
   label = in_data[2]
   y = out_data[1]
   dx = in_grad[1]

--- a/examples/julia-softmax.jl
+++ b/examples/julia-softmax.jl
@@ -1,0 +1,59 @@
+using MXNet
+
+import MXNet.mx.Native: Operator, list_arguments, list_outputs, infer_shape,
+                        forward, backward, need_top_grad
+immutable JuliaSoftmax <: Operator end
+
+list_arguments(:: JuliaSoftmax) = ["data", "label"]
+list_outputs(:: JuliaSoftmax) = ["output"]
+need_top_grad(:: JuliaSoftmax) = false
+
+function infer_shape(::JuliaSoftmax, in_shape)
+  data_shape = in_shape[1]
+  label_shape = (in_shape[1][1],)
+  output_shape = in_shape[1]
+  return [data_shape, label_shape], [output_shape]
+end
+
+function forward(::JuliaSoftmax, in_data, out_data)
+  x = in_data[1]
+  y = out_data[1]
+
+  @mx.nd_as_jl ro=x rw=y begin
+    y[:] = exp(x - maximum(x, 1))
+    y /= sum(y, 1)
+  end
+end
+
+#TODO: Correct gradient
+function backward(::JuliaSoftmax, out_grad, in_data, out_data, in_grad)
+  label = in_data[2]
+  y = out_data[1]
+  dx = in_grad[1]
+
+  @mx.nd_as_jl ro=(label, y) rw=dx begin
+    dx[:] = y
+  end
+end
+
+#define mlp
+data = mx.Variable("data")
+fc1 = mx.FullyConnected(data = data, name="fc1", num_hidden=128)
+act1 = mx.Activation(data = fc1, name="relu1", act_type="relu")
+fc2 = mx.FullyConnected(data = act1, name="fc2", num_hidden=64)
+act2 = mx.Activation(data = fc2, name="relu2", act_type="relu")
+fc3 = mx.FullyConnected(data = act2, name="fc3", num_hidden=10)
+
+# Setup Native operator
+mysoftmax = JuliaSoftmax()
+info = mx.Native.NDArrayOpInfo(mysoftmax)
+pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
+mlp = mx._Native(name = "softmax", info = pstring, data=fc3)
+
+model = mx.FeedForward(mlp, context = mx.cpu())
+optimizer = mx.SGD(lr = 0.1, momentum = 0.9, weight_decay = 0.00001)
+
+include("mnist/mnist-data.jl")
+train_provider, eval_provider = get_mnist_providers(100)
+mx.fit(model, optimizer, train_provider, eval_data=eval_provider, n_epoch =20 )
+

--- a/examples/julia-softmax.jl
+++ b/examples/julia-softmax.jl
@@ -2,7 +2,7 @@ using MXNet
 
 import MXNet.mx.Native: Operator, list_arguments, list_outputs, infer_shape,
                         forward, backward, need_top_grad
-immutable JuliaSoftmax <: Operator end
+type JuliaSoftmax <: Operator end
 
 list_arguments(:: JuliaSoftmax) = ["data", "label"]
 list_outputs(:: JuliaSoftmax) = ["output"]

--- a/src/MXNet.jl
+++ b/src/MXNet.jl
@@ -37,6 +37,7 @@ include("kvstore.jl")
 include("callback.jl")
 include("model.jl")
 
+include("nativeops.jl")
 include("visualize.jl")
 
 include("nn-factory.jl")

--- a/src/base.jl
+++ b/src/base.jl
@@ -60,6 +60,21 @@ macro mxcall(fv, argtypes, args...)
   end
 end
 
+"Utility macro to call MXNet API functions from a threadpool"
+macro mxthreadcall(fv, argtypes, args...)
+  f = eval(fv)
+  args = map(esc, args)
+  quote
+    _mxret = @threadcall( ($(Meta.quot(f)), $MXNET_LIB),
+                    Cint, $argtypes, $(args...) )
+    if _mxret != 0
+      err_msg = mx_get_last_error()
+      throw(MXError(err_msg))
+    end
+  end
+end
+
+
 ################################################################################
 # Handle types
 ################################################################################

--- a/src/executor.jl
+++ b/src/executor.jl
@@ -164,7 +164,9 @@ function forward(self :: Executor; is_train::Bool=false, kwargs...)
     copy!(self.arg_dict[k], v)
   end
 
-  @mxcall(:MXExecutorForward, (MX_handle, Cint), self, is_train)
+  println("Forward")
+  @mxthreadcall(:MXExecutorForward, (MX_handle, Cint), self, is_train)
+  println("Forward")
 end
 
 function backward(self :: Executor)
@@ -175,7 +177,9 @@ function backward(self :: Executor, out_grad :: NDArray)
 end
 function backward(self :: Executor, out_grads :: Vector{NDArray})
   out_grads = MX_handle[out_grads...]
-  @mxcall(:MXExecutorBackward, (MX_handle, MX_uint, Ptr{MX_handle}), self, length(out_grads), out_grads)
+  println("Backward")
+  @mxthreadcall(:MXExecutorBackward, (MX_handle, MX_uint, Ptr{MX_handle}), self, length(out_grads), out_grads)
+  println("Backward")
 end
 
 

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -147,7 +147,7 @@ type NDArrayOpInfo
     # The return value of the callbacks is stored in _FB and the first element is the
     # libuv handle.
     r_forward = Ref(_FB(cb_f.handle))
-    r_backward = Ref(_FB(cb_f.handle))
+    r_backward = Ref(_FB(cb_b.handle))
 
     p_f = Base.unsafe_convert(Ptr{Void}, r_forward)
     p_b = Base.unsafe_convert(Ptr{Void}, r_backward)

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -162,9 +162,9 @@ type NDArrayOpInfo
       try
         while true
            wait(f_cond)
-           RawMutex.unlock(m_fentry)
            # do we meed to replace the AsyncCondition?
            _entry_forward(op, r_forward[])
+           RawMutex.unlock(m_fentry)
            RawMutex.wait(b_fexit)
         end
       catch
@@ -180,9 +180,9 @@ type NDArrayOpInfo
     @schedule begin
       try
         while true
-           wait(f_cond)
-           RawMutex.unlock(m_bentry)
+           wait(b_cond)
            _entry_backward(op, r_backward[])
+           RawMutex.unlock(m_bentry)
            RawMutex.wait(b_bexit)
         end
       catch

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -185,8 +185,9 @@ function _wrapper_infer(size :: Cint, ndims :: Ptr{Cint}, tensor_shapes :: Ptr{P
       tshapes = unsafe_load(tensor_shapes, i)
       # Copy values
       for j in 1:jj
-        r_shapes[j] = unsafe_load(tshapes, jj - (j-1)) # reverse Shapes.
+        r_shapes[j] = unsafe_load(tshapes, j)
       end
+      reverse!(r_shapes)
       push!(shapes, r_shapes)
     end
 

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -1,0 +1,78 @@
+###
+# NativeOpInfo mirrors the struct in include/mxnet/c_api.h and consists of five function
+# pointers that work as callbacks. Each p_... ia a opaque pointer that contains the
+# necessary information to call the right function.
+###
+immutable NativeOpInfo
+  forward :: Ptr{Void}
+  backward :: Ptr{Void}
+  infer_shape :: Ptr{Void}
+  list_outputs :: Ptr{Void}
+  list_arguments :: Ptr{Void}
+  p_forward :: Ptr{Void}
+  p_backward :: Ptr{Void}
+  p_infer_shape :: Ptr{Void}
+  p_list_outputs :: Ptr{Void}
+  p_list_arguments :: Ptr{Void}
+
+  function NativeOpInfo(forward :: Function, backwards :: Function, infer_shape :: Function, list_outputs :: Function, list_arguments :: Function)
+    p_f  = pointer_from_objref(forward)
+    p_b  = pointer_from_objref(backwards)
+    p_is = pointer_from_objref(infer_shape)
+    p_lo = pointer_from_objref(list_outputs)
+    p_la = pointer_from_objref(list_arguments)
+    new(c_wrapper_fb, c_wrapper_fb, c_wrapper_infer, c_wrapper_list,
+        c_wrapper_list, p_f, p_b, p_is, p_lo, p_la)
+  end
+end
+
+###
+# Each _wrapper_... is the entry point for the c function call that converts the opaque
+# pointer into the right julia function.
+###
+
+function _wrapper_fb(size :: Cint, data :: Ptr{Ptr{Cfloat}}, ndims :: Ptr{Cint}, shapes :: Ptr{Ptr{Cuint}}, tags :: Ptr{Cint}, jf :: Ptr{Void})
+  julia_function = unsafe_pointer_to_objref(jf) :: Function
+  julia_function(Int(size), data, ndims, shapes, tags)
+  return nothing
+end
+
+const c_wrapper_fb = cfunction(_wrapper_fb, Void, (Cint, Ptr{Ptr{Cfloat}}, Ptr{Cint}, Ptr{Ptr{Cuint}}, Ptr{Cint}, Ptr{Void}))
+
+function _wrapper_infer(size :: Cint, ndims :: Ptr{Cint}, shapes :: Ptr{Ptr{Cuint}}, jf :: Ptr{Void})
+  julia_function = unsafe_pointer_to_objref(jf) :: Function
+  julia_function(Int(size), ndims, shapes)
+  return nothing
+end
+
+const c_wrapper_infer = cfunction(_wrapper_infer, Void, (Cint, Ptr{Cint}, Ptr{Ptr{Cuint}}, Ptr{Void}))
+
+function _wrapper_list(data :: Ptr{Ptr{Ptr{Cchar}}}, jf :: Ptr{Void})
+  julia_function = unsafe_pointer_to_objref(jf) :: Function
+  julia_function(data)
+  return nothing
+end
+
+const c_wrapper_list = cfunction(_wrapper_list, Void, (Ptr{Ptr{Ptr{Cchar}}}, Ptr{Void}))
+
+###
+# Test entry functions
+###
+
+function list_entry(a :: Ptr{Ptr{Ptr{Cchar}}})
+  data = ByteString[""]
+  ref = Base.cconvert(Ptr{Ptr{Cchar}}, data)
+  ptr = Base.unsafe_convert(Ptr{Ptr{Cchar}}, ref)
+  unsafe_store!(a, ptr,1)
+end
+
+function fb_entry(num_tensor :: Cint, in :: Ptr{Ptr{Cfloat}}, x :: Ptr{Cint}, y :: Ptr{Cuint}, z :: Ptr{Cint})
+end
+
+function infer_entry(num_tensor :: Cint, tensor_dims :: Ptr{Cint}, tensor_shapes :: Ptr{Ptr{Cuint}})
+end
+
+# info = NativeOpInfo(fb_entry, fb_entry, infer_entry, list_entry, list_entry)
+# pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
+# mx._Native(name = :test, info = pstring)
+

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -68,7 +68,7 @@ need_top_grad(:: Operator) = true
   Return value needs to be an integer array.
 =#
 function declare_backward_dependency(op :: Operator, out_grad :: Vector{Int32}, in_data :: Vector{Int32}, out_data :: Vector{Int32})
-  deps = Int[]
+  deps = Int32[]
   if need_top_grad(op)
     append!(deps, out_grad)
   end
@@ -264,7 +264,7 @@ function _wrapper_declare_backward_dependency(_out_grad :: Ptr{Cint},
     in_data = pointer_to_array(_in_data, length(list_arguments(op)), false) :: Vector{Int32}
     out_data = pointer_to_array(_out_data, length(list_outputs(op)), false) :: Vector{Int32}
 
-    rdeps = declare_backward_dependency(op, out_grad, in_data, out_data) :: Vector{Int32}
+    rdeps = convert(Vector{Cint}, declare_backward_dependency(op, out_grad, in_data, out_data))
 
     unsafe_store!(num_dep, length(rdeps), 1)
     r_rdeps = Ref(rdeps) # Lifetime?

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -15,22 +15,22 @@ abstract Operator
 #=doc
 .. function:: forward(op :: Operator, in_data, out_data)
 =#
-function forward(:: Operator, in_data, out_data)
-  out_data[0][:] = in_data[0]
+function forward(op :: Operator, in_data, out_data)
+  throw(MethodError(forward, (op, in_data, out_data)))
 end
 
 #=doc
 .. function:: backward(op :: Operator, out_grad, in_data, out_data, in_grad)
 =#
-function backward(:: Operator, out_grad, in_data, out_data, in_grad)
-  in_grad[0][:] = 1.0
+function backward(op :: Operator, out_grad, in_data, out_data, in_grad)
+  throw(MethodError(backward, (op, out_grad, in_data, out_data, in_grad)))
 end
 
 #=doc
 .. function:: infer_shape(op :: Operator, in_shape)
 =#
-function infer_shape(:: Operator, in_shape)
-   return (in_shape, ), ([in_shape[0]], )
+function infer_shape(op :: Operator, shapes :: Vector{Vector{Cuint}})
+  throw(MethodError(infer_shape, (op, shapes)))
 end
 
 #=doc

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -247,12 +247,11 @@ function _entry_forward(op :: Operator, payload :: _FB)
 
   # Tags are zero-based
   for i in 1:num_ndarray
+    handle = MX_NDArrayHandle(ndarries[i])
     if tags[i] == 1
-      #tensors[tags[i]+1].append(NDArray(cast(ndarraies[i], NDArrayHandle),
-      #                                writable=True))
+      push!(tags[i] + 1, NDArray(handle, true))
     else
-      #tensors[tags[i]+1].append(NDArray(cast(ndarraies[i], NDArrayHandle),
-      #                                writable=False))
+      push!(tags[i] + 1, NDArray(handle, false))
     end
   end
   forward(op, tensors[1], tensors[2])
@@ -267,12 +266,11 @@ function _entry_backward(op :: Operator, payload :: _FB)
   tensors = [[] for i in 1:4]
 
   for i in 1:num_ndarray
+    handle = MX_NDArrayHandle(ndarries[i])
     if tags[i] == 2
-      #tensors[tags[i]+1].append(NDArray(cast(ndarraies[i], NDArrayHandle),
-      #                                writable=True))
+      push!(tags[i] + 1, NDArray(handle, true))
     else
-      #tensors[tags[i]+1].append(NDArray(cast(ndarraies[i], NDArrayHandle),
-      #                                writable=False))
+      push!(tags[i] + 1, NDArray(handle, false))
     end
   end
   backward(op, tensors[1], tensors[2], tensors[3], tensors[4])

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -3,6 +3,7 @@ Native operators in Julia
 =========================
 =#
 module Native
+import ..mx
 import ..mx: NDArray
 
 #=doc

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -30,43 +30,15 @@ immutable NativeOpInfo
   end
 end
 
-###
-# Each _wrapper_... is the entry point for the c function call.
-# It receives an opaque pointer to the correct entry function and
-# the function parameters. It then wraps the function parameters in the
-# correct immutable T <: _MXNET_DATA and creates an _Async object from it.
-# _Async reimplements and extends Base.SingleAsyncWork to also pass some data
-# and a Condition along. That condition is then used to synchronize
-# the _wrapper and _entry functions. If we wouldn't synchronize them the
-# _wrapper functions would return before the _entry functions have been run.
-# Returning illegal state to MXNet.
-###
-abstract _MXNET_DATA
+##
+# Forward and backward can be called from different threads in libmxnet and
+# so we need to take special care in handling these callbacks correctly in
+# the julia runtime.
+##
 
-# Based on Base.SingleAsyncWork
-immutable _Async{T <: _MXNET_DATA}
-  data :: T
-
+# Callback struct for forward-backward
+immutable _FB
   handle :: Ptr{Void}
-  cb :: Function
-  cond :: Condition
-
-  function _Async(data :: T, cb::Function)
-    this = new(data, Libc.malloc(Base._sizeof_uv_async), cb, Condition())
-    Base.associate_julia_struct(this.handle, this)
-    Base.preserve_handle(this)
-
-    async_cb = cfunction(cb, Void, (Ptr{Void},))
-
-    err = ccall(:uv_async_init,Cint,(Ptr{Void},Ptr{Void},Ptr{Void}),Base.eventloop(),this.handle,async_cb::Ptr{Void})
-
-    this
-  end
-end
-
-Base._uv_hook_close(t::_Async) = (uv.handle = C_NULL; unpreserve_handle(uv); nothing)
-
-immutable _FB <: _MXNET_DATA
   size :: Cint
   data :: Ptr{Ptr{Cfloat}}
   ndims :: Ptr{Cint}
@@ -74,88 +46,34 @@ immutable _FB <: _MXNET_DATA
   tags :: Ptr{Cint}
 end
 
-function _wrapper_fb(size :: Cint, data :: Ptr{Ptr{Cfloat}}, ndims :: Ptr{Cint}, shapes :: Ptr{Ptr{Cuint}}, tags :: Ptr{Cint}, jf :: Ptr{Void})
-  entry = unsafe_pointer_to_objref(jf) :: Function
-  cb_data = _FB(size, data, ndims, shapes, tags)
-  work = _Async{_FB}(cb_data, entry) # We have to specify T here otherwise inference will run and seqfault.
-  ccall(:uv_async_send, Void, (Ptr{Void},), work.handle)
-  wait(work.cond)
-  return nothing
+@assert isbits(_FB)
+
+function _wrapper_fb(size :: Cint, data :: Ptr{Ptr{Cfloat}}, ndims :: Ptr{Cint}, shapes :: Ptr{Ptr{Cuint}}, tags :: Ptr{Cint}, payload :: Ptr{Void})
+  # Load the libuv async handle
+  ptr = convert(Ptr{_FB}, payload)
+  handle = unsafe_load(ptr, 1).handle
+
+  # Create result
+  val = _FB(handle, size, data, ndims, shapes, tags)
+  unsafe_store!(ptr, val, 1)
+
+  ccall(:uv_async_send, Void, (Ptr{Void},), handle)
+  nothing
 end
 
-immutable _INFER <: _MXNET_DATA
-  size :: Cint
-  ndims :: Ptr{Cint}
-  shapes :: Ptr{Ptr{Cuint}}
-end
-
+###
+# Infer and list are called in sync.
+###
 function _wrapper_infer(size :: Cint, ndims :: Ptr{Cint}, shapes :: Ptr{Ptr{Cuint}}, jf :: Ptr{Void})
   entry = unsafe_pointer_to_objref(jf) :: Function
-  cb_data = _INFER(size, ndims, shapes)
-  work = _Async{_INFER}(cb_data, entry)
-  ccall(:uv_async_send, Void, (Ptr{Void},), work.handle)
-  wait(work.cond)
+  entry(size, ndims, shapes)
   return nothing
 end
 
-immutable _LIST <: _MXNET_DATA
-  result :: Ptr{Ptr{Ptr{Cchar}}}
-end
-
-function _wrapper_list(data :: Ptr{Ptr{Ptr{Cchar}}}, jf :: Ptr{Void})
+function _wrapper_list(data :: Ptr{Ptr{Cstring}}, jf :: Ptr{Void})
   entry = unsafe_pointer_to_objref(jf) :: Function
-  cb_data = _LIST(data)
-  work = _Async{_LIST}(cb_data, entry)
-  ccall(:uv_async_send, Void, (Ptr{Void},), work.handle)
-  wait(work.cond)
+  entry(data)
   return nothing
-end
-
-###
-# Entry functions
-# These functions are now executed in the main Julia thread.
-###
-
-function list_entry(handle :: Ptr{Void})
-  work = Base.@handle_as handle _Async{_LIST}
-  try
-    data = ByteString[""]
-    ref = Base.cconvert(Ptr{Ptr{Cchar}}, data)
-    ptr = Base.unsafe_convert(Ptr{Ptr{Cchar}}, ref)
-    unsafe_store!(work.data.result, ptr,1)
-  catch
-  finally
-    notify(work.cond)
-  end
-  nothing
-end
-
-function fb_entry(handle :: Ptr{Void})
-  work = Base.@handle_as handle _Async{_FB}
-  try
-    data = work.data
-    # do data conversion
-    # call appropriate julia function
-    # store result
-  catch
-  finally
-    notify(work.cond)
-  end
-  nothing
-end
-
-function infer_entry(handle :: Ptr{Void})
-  work = Base.@handle_as handle _Async{_INFER}
-  try
-    data = work.data
-    # do data conversion
-    # call appropriate julia function
-    # store result
-  catch
-  finally
-    notify(work.cond)
-  end
-  nothing
 end
 
 create_info() = NativeOpInfo(fb_entry, fb_entry, infer_entry, list_entry, list_entry)

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -31,7 +31,7 @@ function Base.call(op :: Operator; kwargs...)
   _store(op, info)
 
   r_info = Ref(info)
-  @show pstring = bytestring("0x", hex(reinterpret(UInt, Base.unsafe_convert(Ptr{Void}, r_info))))
+  pstring = bytestring("0x", hex(reinterpret(UInt, Base.unsafe_convert(Ptr{Void}, r_info))))
   mx._NDArray(info = pstring; kwargs...)
 end
 
@@ -346,6 +346,8 @@ function _entry_forward(op :: Operator, payload :: _FB)
     tag = unsafe_load(tags, i)
     if tag == 1
       push!(tensors[tag + 1], NDArray(handle, true))
+    elseif !(0 <= tag < 4)
+      error("Received incorrect tag: $tag")
     else
       push!(tensors[tag + 1], NDArray(handle, false))
     end
@@ -366,6 +368,8 @@ function _entry_backward(op :: Operator, payload :: _FB)
     tag = unsafe_load(tags, i)
     if tag == 2
       push!(tensors[tag + 1], NDArray(handle, true))
+    elseif !(0 <= tag < 4)
+      error("Received incorrect tag: $tag")
     else
       push!(tensors[tag + 1], NDArray(handle, false))
     end

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -1,3 +1,29 @@
+module Native
+
+abstract Operator
+
+function forward(:: Operator, in_data, out_data)
+  out_data[0][:] = in_data[0]
+end
+
+function backward(:: Operator, out_grad, in_data, out_data, in_grad)
+  in_grad[0][:] = 1.0
+end
+
+function infer_shape(:: Operator, in_shape)
+   return in_shape, [in_shape[0]]
+end
+
+function list_outputs(:: Operator)
+  return ["output"]
+end
+
+function list_arguments(:: Operator)
+  return ["data"]
+end
+
+need_top_grad(:: Operator) = true
+
 ###
 # NativeOpInfo mirrors the struct in include/mxnet/c_api.h and consists of five function
 # pointers that work as callbacks. Each p_... ia a opaque pointer that contains the
@@ -79,3 +105,4 @@ end
 create_info() = NativeOpInfo(fb_entry, fb_entry, infer_entry, list_entry, list_entry)
 # pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
 # mx._Native(name = :test, info = pstring)
+end

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -177,7 +177,7 @@ function _wrapper_infer(size :: Cint, ndims :: Ptr{Cint}, tensor_shapes :: Ptr{P
       tshapes = unsafe_load(tensor_shapes, i)
       # Copy values
       for j in 1:jj
-        r_shapes[j] = unsafe_load(tshapes, j)
+        r_shapes[j] = unsafe_load(tshapes, jj - (j-1)) # reverse Shapes.
       end
       push!(shapes, r_shapes)
     end
@@ -189,6 +189,7 @@ function _wrapper_infer(size :: Cint, ndims :: Ptr{Cint}, tensor_shapes :: Ptr{P
     rshapes = Vector{Cuint}[ishape..., oshape...]
 
     for i in 1:size
+      reverse!(rshapes[i]) # reverse shapes back
       unsafe_store!(tensor_shapes, pointer(rshapes[i]), i)
       unsafe_store!(ndims, length(rshapes[i]), i)
     end

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -186,6 +186,7 @@ function _wrapper_list_arguments(data :: Ptr{Ptr{Ptr{Cchar}}}, _op :: Ptr{Void})
   try
     op = unsafe_pointer_to_objref(_op) :: Operator
     arguments = list_arguments(op)
+    push!(arguments, "")
     ptrs = Ptr{Cchar}[Base.unsafe_convert(Ptr{Cchar}, arguments[i]) for i in eachindex(arguments)]
     r_args = Ref(ptrs)
     unsafe_store!(data,  Base.unsafe_convert(Ptr{Ptr{Cchar}}, r_args))
@@ -200,6 +201,7 @@ function _wrapper_list_outputs(data :: Ptr{Ptr{Ptr{Cchar}}}, _op :: Ptr{Void})
   try
     op = unsafe_pointer_to_objref(_op) :: Operator
     outputs = list_outputs(op)
+    push!(outputs, "")
     ptrs = Ptr{Cchar}[Base.unsafe_convert(Ptr{Cchar}, outputs[i]) for i in eachindex(outputs)]
     r_out = Ref(ptrs)
     unsafe_store!(data, Base.unsafe_convert(Ptr{Ptr{Cchar}}, r_out))

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -181,28 +181,35 @@ function _wrapper_infer(size :: Cint, ndims :: Ptr{Cint}, shapes :: Ptr{Ptr{Cuin
   return true
 end
 
+# TODO: Lifetime of julia objects (GC!)
 function _wrapper_list_arguments(data :: Ptr{Ptr{Ptr{Cchar}}}, _op :: Ptr{Void})
   try
     op = unsafe_pointer_to_objref(_op) :: Operator
     arguments = list_arguments(op)
-    unsafe_store!(data, arguments)
+    ptrs = Ptr{Cchar}[Base.unsafe_convert(Ptr{Cchar}, arguments[i]) for i in eachindex(arguments)]
+    r_args = Ref(ptrs)
+    unsafe_store!(data,  Base.unsafe_convert(Ptr{Ptr{Cchar}}, r_args))
   catch
     return false
   end
   return true
 end
 
+# TODO: Lifetime of julia objects (GC!)
 function _wrapper_list_outputs(data :: Ptr{Ptr{Ptr{Cchar}}}, _op :: Ptr{Void})
   try
     op = unsafe_pointer_to_objref(_op) :: Operator
     outputs = list_outputs(op)
-    unsafe_store!(data, outputs)
+    ptrs = Ptr{Cchar}[Base.unsafe_convert(Ptr{Cchar}, outputs[i]) for i in eachindex(outputs)]
+    r_out = Ref(ptrs)
+    unsafe_store!(data, Base.unsafe_convert(Ptr{Ptr{Cchar}}, r_out))
   catch
     return false
   end
   return true
 end
 
+# TODO: Lifetime of julia objects (GC!)
 function _wrapper_declare_backward_dependency(_out_grad :: Ptr{Cint},
                                               _in_data  :: Ptr{Cint},
                                               _out_data :: Ptr{Cint},

--- a/src/nativeops.jl
+++ b/src/nativeops.jl
@@ -13,6 +13,12 @@ import ..mx: NDArray
 =#
 abstract Operator
 
+function Base.call(op :: Operator; kwargs...)
+  info = NDArrayOpInfo(op)
+  pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
+  mx._NDArray(info = pstring; kwargs...)
+end
+
 #=doc
 .. function:: forward(op :: Operator, in_data :: Vector{NDArray}, out_data :: Vector{NDArray})
 =#


### PR DESCRIPTION
Thanks to the help in #15 I managed to get past the initialization stage of _Native.


With the test_enty functions defined in src/nativeops.jl
````
info = mx.NativeOpInfo(fb_entry, fb_entry, infer_entry, list_entry, list_entry)
pstring = bytestring("0x", hex(reinterpret(UInt, pointer_from_objref(info))))
mx._Native(name = :test, info = pstring)
````

Works without causing a seqfault :tada:

Todo:
- [ ] Defining API exposed to Users
- [ ] Defining (gc-safe) entry points (maybe also thread safe?)

### API
I was thinking of something along the lines of
````
immutable Softmax <: mx.NativeOp end

function forward(::Type{Softmax}, in_data, out_data)
  ...
end

function forward(::Type{Softmax}, out_grad, in_data, out_data, in_grad)
  ...
end

function infer_shape(::Type{Softmax},  in_shape)
  ...
end

function list_output(::Type{Softmax})
  ...
end

function list_output(::Type{Softmax})
  ...
end
````