### PR TITLE
fix the sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ mlp = @mx.chain mx.Variable(:data) =>
 
 # data provider
 batch_size = 100
-include(joinpath(Pkg.dir("MXNet"), "examples/mnist/mnist-data.jl"))
+include(Pkg.dir("MXNet", "examples", "mnist", "mnist-data.jl"))
 train_provider, eval_provider = get_mnist_providers(batch_size)
 
 # setup model


### PR DESCRIPTION
This path separator will now work on Windows; instead,  you can pass variable number of arguments to `Pkg.dir`, which automatically does `joinpath` for the arguments.