### PR TITLE
Rework Xavier to be more flexibility

### DIFF
--- a/docs/api/initializer.rst
+++ b/docs/api/initializer.rst
@@ -73,16 +73,9 @@ Built-in initializers
    Several different ways of calculating the variance are given in the literature or are
    used by various libraries.
 
-   - original [Bengio and Glorot 2010]: σ² = 2 / (in + out)
-   - msra [K. He, X. Zhang, S. Ren, and J. Sun 2015]: σ² = 2 / in
-   - caffe_avg: 6 / (in + out)
-   - caffe_in: 3 / in
-   - caffe_out: 3 / out
-   - mxnet: 3 / (in + out)
-
-   Distribution and variant can be chosen by enums (prefixed by ``xv_``).
-   As an example take ``mx.XavierInitializer(distribution = mx.xv_normal, variant = mx.xv_mxnet)``,
-   which is currently the default.
+   - [Bengio and Glorot 2010]: ``mx.XavierInitializer(distribution = mx.xv_uniform, regularization = mx.xv_avg, magnitude = 1)``
+   - [K. He, X. Zhang, S. Ren, and J. Sun 2015]: ``mx.XavierInitializer(distribution = mx.xv_gaussian, regularization = mx.xv_in, magnitude = 2)``
+   - caffe_avg: ``mx.XavierInitializer(distribution = mx.xv_uniform, regularization = mx.xv_avg, magnitude = 3)``
 
 
 

--- a/docs/api/io.rst
+++ b/docs/api/io.rst
@@ -324,7 +324,7 @@ libmxnet data providers
    
    
    :param prefetch_buffer: Backend Param: Number of prefetched parameters
-   :type prefetch_buffer: , optional, default=4
+   :type prefetch_buffer: long (non-negative), optional, default=4
    
    
    :param rand_crop: Augmentation Param: Whether to random crop on the image
@@ -467,7 +467,7 @@ libmxnet data providers
    
    
    :param prefetch_buffer: Backend Param: Number of prefetched parameters
-   :type prefetch_buffer: , optional, default=4
+   :type prefetch_buffer: long (non-negative), optional, default=4
    
    :return: the constructed :class:`MXDataProvider`.
 

--- a/docs/api/symbolic-node.rst
+++ b/docs/api/symbolic-node.rst
@@ -872,41 +872,6 @@ Internal APIs
 
 
 
-.. function:: _Power(...)
-
-   Perform an elementwise power.
-   
-   :param Base.Symbol name: The name of the :class:`SymbolicNode`. (e.g. `:my_symbol`), optional.
-   
-   :return: the constructed :class:`SymbolicNode`.
-   
-
-
-
-
-.. function:: _PowerScalar(...)
-
-   Perform an elementwise power.
-   
-   :param array: Input array operand to the operation.
-   :type array: SymbolicNode
-   
-   
-   :param scalar: scalar value.
-   :type scalar: float, required
-   
-   
-   :param scalar_on_right: scalar operand is on the right.
-   :type scalar_on_right: boolean, optional, default=False
-   
-   :param Base.Symbol name: The name of the :class:`SymbolicNode`. (e.g. `:my_symbol`), optional.
-   
-   :return: the constructed :class:`SymbolicNode`.
-   
-
-
-
-
 
 
 


### PR DESCRIPTION
Following the discussion in https://github.com/dmlc/mxnet/pull/610 I took another swing at Xavier.

The idea is that the concepts proposed in the papers [1, 2, 3] can be generalized in choosing the regularization factor `1/fan_in` `1/fan_out` `2/(fan_out + fan_in)`, the distribution to sample from and a magnitude scaling factor. [1] proposes `3/fan_in` and `6/(fan_out+fan_in)` and [2,3] propose `2/fan_in`. 

[1] X. Bengio and Y. Glorot (2010) http://jmlr.csail.mit.edu/proceedings/papers/v9/glorot10a.html
[2] K. He, X. Zhang, S. Ren, and J. Sun (2015) http://arxiv.org/abs/1502.01852
[3] A. M. Saxe, J. L. McClelland, and S. Ganguli (2013/2014) http://arxiv.org/abs/1312.6120v3