### PR TITLE
[RFC/WIP] Bilinear initializer

### DIFF
--- a/examples/Bilinear_upsampling.ipynb
+++ b/examples/Bilinear_upsampling.ipynb
@@ -1,0 +1,481 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bilinear upsampling with Deconvolution layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "using MXNet\n",
+    "using Images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate the appropriate kernel size for scaling factor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "factor = 3\n",
+    "kernel = 2factor - factor % 2\n",
+    "stride = factor\n",
+    "pad = ceil(Int64, (factor - 1) / 2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       ":deconvolution0_weight"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = mx.Variable(:data)\n",
+    "deconv = mx.Deconvolution(data = data, num_filter = 1,\n",
+    "                          kernel = (kernel, kernel),\n",
+    "                          stride = (stride, stride),\n",
+    "                          pad = (pad, pad), no_bias=true)\n",
+    "deconv_w =  mx.list_arguments(deconv)[2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create test image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"\n",
+       "     width=\"45.0mm\" height=\"45.0mm\"\n",
+       "     shape-rendering=\"crispEdges\">\n",
+       "<rect x=\"0.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#000000\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#404040\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#404040\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#BFBFBF\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#BFBFBF\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#FFFFFF\" stroke=\"none\" />\n",
+       "</svg>"
+      ],
+      "text/plain": [
+       "Gray Images.Image with:\n",
+       "  data: 3x3 Array{ColorTypes.Gray{Float64},2}\n",
+       "  properties:\n",
+       "    colorspace: Gray\n",
+       "    spatialorder:  x y"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = zeros(3, 3, 1, 1) # width, height, channels, samples\n",
+    "data[:, :, 1, 1] = [[0 0.25 0.5]; [0.25 0.5 0.75]; [0.5 0.75 1]]\n",
+    "original = grayim(data[:, :, 1, 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([:data,:deconvolution0_weight],Any[:deconvolution0_weight],Symbol[])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dp = mx.ArrayDataProvider(data, batch_size = 1)\n",
+    "model = mx.FeedForward(deconv)\n",
+    "mx.init_model(model, Dict(:default => mx.UniformInitializer(), deconv_w => mx.BilinearInitializer()), data=size(data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run network over data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n",
+       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"\n",
+       "     width=\"135.0mm\" height=\"135.0mm\"\n",
+       "     shape-rendering=\"crispEdges\">\n",
+       "<rect x=\"0.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#000000\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#000000\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#0E0E0E\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#1C1C1C\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#2B2B2B\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#393939\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#474747\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"0.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#393939\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#000000\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#000000\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#151515\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#2B2B2B\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#404040\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#6A6A6A\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"15.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#0E0E0E\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#151515\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#2B2B2B\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#404040\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#6A6A6A\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#959595\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"30.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#636363\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#1C1C1C\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#2B2B2B\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#404040\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#6A6A6A\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#959595\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"45.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#717171\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#2B2B2B\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#404040\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#6A6A6A\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#959595\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#BFBFBF\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"60.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#393939\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#6A6A6A\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#959595\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#BFBFBF\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#D5D5D5\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"75.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#8E8E8E\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#474747\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#6A6A6A\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#959595\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#BFBFBF\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#D5D5D5\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#EAEAEA\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"90.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#9C9C9C\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#959595\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#BFBFBF\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#D5D5D5\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#EAEAEA\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#FFFFFF\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"105.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"0.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#393939\" stroke=\"none\" />\n",
+       "<rect x=\"15.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#555555\" stroke=\"none\" />\n",
+       "<rect x=\"30.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#636363\" stroke=\"none\" />\n",
+       "<rect x=\"45.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#717171\" stroke=\"none\" />\n",
+       "<rect x=\"60.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#808080\" stroke=\"none\" />\n",
+       "<rect x=\"75.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#8E8E8E\" stroke=\"none\" />\n",
+       "<rect x=\"90.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#9C9C9C\" stroke=\"none\" />\n",
+       "<rect x=\"105.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#AAAAAA\" stroke=\"none\" />\n",
+       "<rect x=\"120.0mm\" y=\"120.0mm\"\n",
+       "      width=\"14.0mm\" height=\"14.0mm\"\n",
+       "      fill=\"#717171\" stroke=\"none\" />\n",
+       "</svg>"
+      ],
+      "text/plain": [
+       "Gray Images.Image with:\n",
+       "  data: 9x9 Array{ColorTypes.Gray{Float32},2}\n",
+       "  properties:\n",
+       "    colorspace: Gray\n",
+       "    spatialorder:  x y"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pred = mx.predict(model, dp)\n",
+    "grayim(pred[:, :, 1, 1])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.4.0",
+   "language": "julia",
+   "name": "julia-0.4"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.4.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This PR adds a Bilinear initializer similar to https://github.com/BVLC/caffe/pull/2213 which is useful for upsampling  with deconvolution. Additionally this allows to set different initializers for different layers.

### Todo
- [ ] Documentation for BilinearInitializer
- [ ] Tests and example
- [ ] Documentation for initializer per layer
- [ ] Setting lr-rate per layer (since we preinitialize to a given function we need to turn learning off)
- [x] Initializing filter correctly for multiple channels

### Setting initializer per layer
````Julia
using MXNet

data = mx.Variable(:data)
pool1 = mx.Pooling(data = data, kernel = (2,2), pool_type = (:max), stride = (2,2))
deconv = mx.Deconvolution(data = pool1, num_filter = 2, kernel = (2,2), stride = (2,2), no_bias=true)

deconv_w = mx.list_arguments(deconv)[2]


data = zeros(64, 64, 1, 10)
dp = mx.ArrayDataProvider(data, batch_size = 1)

model = mx.FeedForward(deconv)
mx.init_model(model, Dict(:default => mx.UniformInitializer(), deconv_w => mx.BilinearInitializer()), data=size(data))
pred = mx.predict(model, dp)
````

### Proper upsampling
````julia
using MXNet

# scaling factor
factor = 2
@show kernel = 2factor - factor % 2
stride = factor
@show pad = ceil(Int64, (factor - 1) / 2)

data = mx.Variable(:data)
deconv = mx.Deconvolution(data = data, num_filter = 1, kernel = (kernel, kernel), stride = (stride, stride), pad = (pad, pad), no_bias=true)

deconv_w = mx.list_arguments(deconv)[2]

data = zeros(3, 3, 1, 1)
for i in 1:3
  for j in 1:3
    data[i, j, 1, 1] = i*j
  end
end

@show data

dp = mx.ArrayDataProvider(data, batch_size = 1)

model = mx.FeedForward(deconv)
mx.init_model(model, Dict(:default => mx.UniformInitializer(), deconv_w => mx.BilinearInitializer()), data=size(data))
pred = mx.predict(model, dp)

@show pred
````
Ref: #31 