### PR TITLE
Fixes usuage of floor

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -41,7 +41,7 @@ end
 """
 function _split_inputs(batch_size :: Int, n_split :: Int)
   @assert(batch_size >= n_split)
-  per_split = floor(Int, batch_size / n_split)
+  per_split = Base.floor(Int, batch_size / n_split)
   counts    = Base.zeros(Int, n_split)+per_split
   extra     = batch_size - sum(counts)
   counts[1:extra] += 1


### PR DESCRIPTION
https://github.com/dmlc/mxnet/pull/717 a PR upstream added `floor`/`ceil`/`round,` which are now imported as operators, causing problems with the native Julia functions. Luckily there is only one usage.