### PR TITLE
imports operators into the namespace to prevent issues

### DIFF
--- a/src/MXNet.jl
+++ b/src/MXNet.jl
@@ -8,6 +8,9 @@ export mx
 module mx
 using Formatting
 
+# Functions from base that we can safely extend and that are defined by libmxnet.
+import Base: round, ceil, floor, cos, sin, abs, sign, exp, sqrt, exp, log, norm
+
 include("base.jl")
 include("context.jl")
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -41,7 +41,7 @@ end
 """
 function _split_inputs(batch_size :: Int, n_split :: Int)
   @assert(batch_size >= n_split)
-  per_split = Base.floor(Int, batch_size / n_split)
+  per_split = floor(Int, batch_size / n_split)
   counts    = Base.zeros(Int, n_split)+per_split
   extra     = batch_size - sum(counts)
   counts[1:extra] += 1


### PR DESCRIPTION
Its probably better to import these explicitly so that multiple-dispatch can take care of it.