### PR TITLE
Solves compilation error on julia 0.4.2

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -43,7 +43,7 @@ function _split_inputs(batch_size :: Int, n_split :: Int)
   @assert(batch_size >= n_split)
   per_split = floor(Int, batch_size / n_split)
   counts    = Base.zeros(Int, n_split)+per_split
-  extra     = batch_size - sum(counts)
+  extra     = batch_size - Base.sum(counts)
   counts[1:extra] += 1
 
   cum = [0, cumsum(counts)...]


### PR DESCRIPTION
Solves the following error:

    MethodError: `sum` has no method matching sum(::Array{Int64,1})
    you may have intended to import Base.sum
     in _split_inputs at /home/x/.julia/v0.4/MXNet/src/model.jl:46
     in fit at /home/x/.julia/v0.4/MXNet/src/model.jl:330
     in mnist_fit_and_predict at /home/x/.julia/v0.4/MXNet/examples/mnist/mlp-test.jl:33
     in anonymous at test.jl:90
     in do_test at test.jl:50
     in test_mnist_mlp at /home/x/.julia/v0.4/MXNet/examples/mnist/mlp-test.jl:75
     in include at ./boot.jl:261
     in include_from_node1 at ./loading.jl:304
     in process_options at ./client.jl:280
     in _start at ./client.jl:378
     in _split_inputs at /home/x/.julia/v0.4/MXNet/src/model.jl:46
     in fit at /home/x/.julia/v0.4/MXNet/src/model.jl:330
     in mnist_fit_and_predict at /home/x/.julia/v0.4/MXNet/examples/mnist/mlp-test.jl:33
     in anonymous at test.jl:90
     in do_test at test.jl:50
     in test_mnist_mlp at /home/x/.julia/v0.4/MXNet/examples/mnist/mlp-test.jl:75
     in include at ./boot.jl:261
     in include_from_node1 at ./loading.jl:304
     in process_options at ./client.jl:280
     in _start at ./client.jl:378
    while loading /home/x/.julia/v0.4/MXNet/examples/mnist/mlp-test.jl, in expression starting on line 79