### PR TITLE
Fix compilation errors for julia 0.4.2

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -435,7 +435,7 @@ immutable ArrayDataBatch <: AbstractDataBatch
   idx :: UnitRange{Int}
 end
 function Base.next(provider :: ArrayDataProvider, state :: ArrayDataProviderState)
-  idx = state.curr_idx:min(state.curr_idx+provider.batch_size-1, provider.sample_count)
+  idx = state.curr_idx:Base.min(state.curr_idx+provider.batch_size-1, provider.sample_count)
   return (ArrayDataBatch(idx), ArrayDataProviderState(idx.stop+1))
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -43,7 +43,7 @@ function _split_inputs(batch_size :: Int, n_split :: Int)
   @assert(batch_size >= n_split)
   per_split = floor(Int, batch_size / n_split)
   counts    = Base.zeros(Int, n_split)+per_split
-  extra     = batch_size - sum(counts)
+  extra     = batch_size - Base.sum(counts)
   counts[1:extra] += 1
 
   cum = [0, cumsum(counts)...]


### PR DESCRIPTION
This fix two errors in the test process:

    ERROR: LoadError: LoadError: MethodError: `min` has no method matching min(::Int64, ::Int64)
    you may have intended to import Base.min
     in next at /home/x/.julia/v0.4/MXNet/src/io.jl:438
     in test_arrays_shuffle at /home/x/.julia/v0.4/MXNet/test/unittest/io.jl:107
     in include at ./boot.jl:261
     in include_from_node1 at ./loading.jl:304
     in anonymous at /home/x/.julia/v0.4/MXNet/test/runtests.jl:10
     in map_to! at abstractarray.jl:1286
     in map at abstractarray.jl:1308
     in test_dir at /home/x/.julia/v0.4/MXNet/test/runtests.jl:9
     in include at ./boot.jl:261
     in include_from_node1 at ./loading.jl:304
     in process_options at ./client.jl:280
     in _start at ./client.jl:378
    while loading /home/x/.julia/v0.4/MXNet/test/unittest/io.jl, in expression starting on line 120
    while loading /home/x/.julia/v0.4/MXNet/test/runtests.jl, in expression starting on line 15


    ERROR: LoadError: MethodError: `sum` has no method matching sum(::Array{Int64,1})
    you may have intended to import Base.sum
     in _split_inputs at /home/x/.julia/v0.4/MXNet/src/model.jl:46
     in fit at /home/x/.julia/v0.4/MXNet/src/model.jl:330
     in include at ./boot.jl:261
     in include_from_node1 at ./loading.jl:304
     in process_options at ./client.jl:280
     in _start at ./client.jl:378
    while loading /home/x/.julia/v0.4/MXNet/examples/mnist/lenet.jl, in expression starting on line 45

