### PR TITLE
[RFC] Freeze layers

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -430,6 +430,16 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
   # invoke callbacks on epoch 0
   _invoke_callbacks(self, opts.callbacks, op_state, AbstractEpochCallback)
 
+  # get grad attribute to allow for freezing
+  freeze_names = Symbol[]
+  for (attr, value) in list_attr(self.arch)
+    sattr = string(attr)
+    if endswith(sattr, "grad") && value == "freeze"
+      push!(freeze_names, symbol(sattr[1:end-5]))
+    end
+  end
+  freeze_idx = filter(i -> in(arg_names[i], freeze_names), 1:length(arg_names))
+
   info("Start training...")
   for i_epoch = 1:opts.n_epoch
     time_start = time()

--- a/src/model.jl
+++ b/src/model.jl
@@ -369,11 +369,31 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
     kvstore, update_on_kvstore = _create_kvstore(kvstore, length(self.ctx), self.arg_params)
   end
 
+  # get grad attribute to allow for freezing
+  freeze_names = Symbol[]
+  for (attr, value) in list_attr(self.arch)
+    sattr = string(attr)
+    if endswith(sattr, "grad") && value == "freeze"
+      push!(freeze_names, symbol(sattr[1:end-5]))
+    end
+  end
+  freeze_idx = filter(i -> in(arg_names[i], freeze_names), 1:length(arg_names))
+
+  # Setup grad_req as a dictionary
+  grad_req = Dict{Symbol, GRAD_REQ}()
+  for param in param_names
+    if in(param, freeze_names)
+      grad_req[param] = GRAD_NOP
+    else
+      grad_req[param] = GRAD_WRITE
+    end
+  end
+
   train_execs = Array(Executor, num_dev)
   for i = 1:num_dev
     data_shapes = [k => tuple(v[1:end-1]...,length(slices[i])) for (k,v) in provide_data(data)]
     label_shapes = [k => tuple(v[1:end-1]...,length(slices[i])) for (k,v) in provide_label(data)]
-    train_execs[i] = simple_bind(self.arch, self.ctx[i]; grad_req=GRAD_WRITE, data_shapes..., label_shapes...)
+    train_execs[i] = simple_bind(self.arch, self.ctx[i]; grad_req=grad_req, data_shapes..., label_shapes...)
     dbg_str = mx.debug_str(train_execs[i])
     info(string("TempSpace: ", split(dbg_str, ['\n'])[end-2]..., " on ", self.ctx[i]))
 
@@ -429,16 +449,6 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
 
   # invoke callbacks on epoch 0
   _invoke_callbacks(self, opts.callbacks, op_state, AbstractEpochCallback)
-
-  # get grad attribute to allow for freezing
-  freeze_names = Symbol[]
-  for (attr, value) in list_attr(self.arch)
-    sattr = string(attr)
-    if endswith(sattr, "grad") && value == "freeze"
-      push!(freeze_names, symbol(sattr[1:end-5]))
-    end
-  end
-  freeze_idx = filter(i -> in(arg_names[i], freeze_names), 1:length(arg_names))
 
   info("Start training...")
   for i_epoch = 1:opts.n_epoch

--- a/src/model.jl
+++ b/src/model.jl
@@ -377,7 +377,8 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
       push!(freeze_names, symbol(sattr[1:end-5]))
     end
   end
-  freeze_idx = filter(i -> in(arg_names[i], freeze_names), 1:length(arg_names))
+  # Needs to correspond to the correct id in the update loop layer idx=1:length(param_names).
+  freeze_idx = filter(i -> in(param_names[i], freeze_names), 1:length(param_names))
 
   # Setup grad_req as a dictionary
   grad_req = Dict{Symbol, GRAD_REQ}()

--- a/src/model.jl
+++ b/src/model.jl
@@ -473,6 +473,10 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
 
       # update parameters
       for idx = 1:length(param_names)
+        if in(idx, freeze_idx)
+          continue # Skip parameter update entirely
+        end
+
         # gradient synchronization
         if !isa(kvstore, Void)
           # push gradient, priority is negative index

--- a/test/unittest/symbolic-node.jl
+++ b/test/unittest/symbolic-node.jl
@@ -100,6 +100,7 @@ function test_attrs()
   @test isnull(mx.get_attr(conv, :b))
   @test get(mx.get_attr(conv, :a)) == "a"
   @test get(mx.get_attr(conv, :π)) == "π"
+  @test mx.list_attr(conv) == Dict(:a => "a", :π => "π")
 
   @test_throws MethodError mx.Variable(:data3, attrs = Dict(:test => "1.0", :test2 => 1.0))
   @test_throws MethodError mx.Convolution(data=data2, kernel = (1,1), num_filter = 1, attrs = Dict(:test => "1.0", :test2 => 1.0))


### PR DESCRIPTION
Setting `attrs = Dict(:grad => "freeze")` on a layer causes it to be ignored in the when updating the weights.

We probably can make this a bit more efficient by setting grad_req=GRAD_NOP in bind for these layers.

This depends on https://github.com/dmlc/mxnet/pull/1965 and fixes #63.