### PR TITLE
Added 7z alternative for mnist allowing test to run on windows

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -19,7 +19,15 @@ function get_mnist_ubyte()
   if !all(isfile, values(filenames))
     cd(mnist_dir) do
       mnist_dir = download("http://webdocs.cs.ualberta.ca/~bx3/data/mnist.zip", "mnist.zip")
-      run(`unzip -u $mnist_dir`)
+        try
+          run(`unzip -u $mnist_dir`)
+        catch
+          try
+            run(pipe(`7z x $mnist_dir`,stdout=DevNull))
+          catch
+            error("Extraction Failed:No extraction program found in path")
+          end
+      end
     end
   end
   return filenames
@@ -34,7 +42,15 @@ function get_cifar10()
   if !all(isfile, values(filenames))
     cd(cifar10_dir) do
       run(`wget http://webdocs.cs.ualberta.ca/~bx3/data/cifar10.zip`)
-      run(`unzip -u cifar10.zip`)
+        try
+          run(`unzip -u cifar10.zip`)
+        catch
+          try
+            run(pipe(`7z x cifar10.zip`,stdout=DevNull))
+          catch
+            error("Extraction Failed:No extraction program found in path")
+          end
+      end
     end
   end
 


### PR DESCRIPTION
Added try catch around the unzip and added `7z` extraction alternative.

If Julia is added to the path, `7z` will be present in the path. `unzip` is not present on windows which caused the `IO::MNIST` to fail.

Added try/catch around the run expressions with an error message about no extraction utility on path. 