### PR TITLE
Change where set_attr is called in _define_atomic_symbol_creator

### DIFF
--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -591,15 +591,15 @@ function _define_atomic_symbol_creator(hdr :: MX_handle; gen_docs=false)
     hint = lowercase($func_name_s)
     name = get!(DEFAULT_NAME_MANAGER, name, hint)
 
-    # set attrs
-    for (k, v) in attrs
-      set_attr(node, k, v)
-    end
-
     if length(args) != 0
       _compose!(node, name, args...)
     else
       _compose!(node; name=name, symbol_kws...)
+    end
+
+    # set attrs
+    for (k, v) in attrs
+      set_attr(node, k, v)
     end
 
     return node


### PR DESCRIPTION
Where `set_attr` was originally called in
`_define_atomic_symbol_creator` would cause `list_attr` to return a
dictionary with extra bias and weight fields as seen here: `
Dict{Symbol,ByteString}(:convolution0_a=>"a",:convolution0_π=>"π",:convolution0_bias_a=>"a",:convolution0_weight_π=>"π",:convolution0_bias_π=>"π",:convolution0_weight_a=>"a",:data2_test=>"hallo!")`

The return now is:`Dict{Symbol,ByteString}(:convolution0_a=>"a",:convolution0_π=>"π",:data2_test=>"hallo!")`

The test still fails however as `list_attr` still contains the name of
the source before the key.

Unsure whether the tests need to be changed to reflect the current return symbols or whether `list_attr` should be modified to try and strip the name information from the keys.