### PR TITLE
[WIP/RFC]Type support for NDArray

### DIFF
--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -6,6 +6,7 @@ NDArray API
 # All the types supported by mshadow.
 typealias DType Union{Float32, Float64, Float16, UInt8, Int32}
 @enum TypeFlag kFloat32 kFloat64 kFloat16 kUint8 kInt32
+typealias DEFAULT_DTYPE Float32
 
 function toTypeFlag{T <: DType}(:: Type{T})
   if T == Float32
@@ -127,13 +128,32 @@ function context(arr :: NDArray)
   return Context(ref_typeid[], ref_devid[])
 end
 
+
+#=doc
+.. function::
+   empty(DType, shape :: Tuple, ctx :: Context)
+   empty(DType, shape :: Tuple)
+   empty(DType, dim1, dim2, ...)
+
+   Allocate memory for an uninitialized :class:`NDArray` with a specified type.
+=#
+function empty{N,T<:DType}(::Type{T}, shape :: NTuple{N, Int})
+  empty(T, shape, cpu())
+end
+function empty{N,T<:DType}(:: Type{T}, shape :: NTuple{N, Int}, ctx :: Context)
+  NDArray(_ndarray_alloc(T, shape, ctx, false))
+end
+function empty{T<:DType}(:: Type{T}, shape :: Int...)
+  empty(T, shape)
+end
+
 #=doc
 .. function::
    empty(shape :: Tuple, ctx :: Context)
    empty(shape :: Tuple)
    empty(dim1, dim2, ...)
 
-   Allocate memory for an uninitialized :class:`NDArray` with specific shape.
+   Allocate memory for an uninitialized :class:`NDArray` with specific shape of type Float32.
 =#
 function empty{N}(shape :: NTuple{N, Int})
   empty(shape, cpu())
@@ -149,6 +169,26 @@ end
 Interface functions similar to Julia Arrays
 -------------------------------------------
 =#
+
+#=doc
+.. function::
+   zeros(DType, shape :: Tuple, ctx :: Context)
+   zeros(DType, shape :: Tuple)
+   zeros(DType, dim1, dim2, ...)
+
+   Create zero-ed :class:`NDArray` with specific shape and type
+=#
+function zeros{N,T<:DType}(:: Type{T}, shape :: NTuple{N, Int})
+  zeros(T, shape, cpu())
+end
+function zeros{N,T<:DType}(:: Type{T}, shape :: NTuple{N, Int}, ctx :: Context)
+  arr = empty(T, shape, ctx)
+  arr[:] = zero(T)
+  return arr
+end
+function zeros{T<:DType}(:: Type{T}, shape :: Int...)
+  zeros(T, shape)
+end
 
 #=doc
 .. function::
@@ -168,6 +208,26 @@ function zeros{N}(shape :: NTuple{N, Int}, ctx :: Context)
 end
 function zeros(shape :: Int...)
   zeros(shape)
+end
+
+#=doc
+.. function::
+   ones(DType, shape :: Tuple, ctx :: Context)
+   ones(DType, shape :: Tuple)
+   ones(DType, dim1, dim2, ...)
+
+   Create an :class:`NDArray` with specific shape & type, and initialize with 1.
+=#
+function ones{N,T<:DType}(:: Type{T}, shape :: NTuple{N, Int})
+  ones(T, shape, cpu())
+end
+function ones{N,T<:DType}(:: Type{T}, shape :: NTuple{N, Int}, ctx :: Context)
+  arr = empty(T, shape, ctx)
+  arr[:] = one(T)
+  return arr
+end
+function ones{T<:DType}(:: Type{T}, shape :: Int...)
+  ones(T, shape)
 end
 
 #=doc

--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -236,53 +236,52 @@ function Group(nodes :: SymbolicNode...)
   SymbolicNode(MX_SymbolHandle(ref_hdr[]))
 end
 
-macro _infer_shape(self, keys, indptr, sdata)
-  quote
-    ref_arg_shape_size = Ref{MX_uint}(0)
-    ref_arg_shape_ndim = Ref{Ptr{MX_uint}}(0)
-    ref_arg_shape_data = Ref{Ptr{Ptr{MX_uint}}}(0)
-    ref_out_shape_size = Ref{MX_uint}(0)
-    ref_out_shape_ndim = Ref{Ptr{MX_uint}}(0)
-    ref_out_shape_data = Ref{Ptr{Ptr{MX_uint}}}(0)
-    ref_aux_shape_size = Ref{MX_uint}(0)
-    ref_aux_shape_ndim = Ref{Ptr{MX_uint}}(0)
-    ref_aux_shape_data = Ref{Ptr{Ptr{MX_uint}}}(0)
-    ref_complete       = Ref{Cint}(0)
-    @mxcall(:MXSymbolInferShape,
-            (MX_handle, MX_uint, char_pp, Ptr{MX_uint}, Ptr{MX_uint},
-             Ref{MX_uint}, Ref{Ptr{MX_uint}}, Ref{Ptr{Ptr{MX_uint}}},
-             Ref{MX_uint}, Ref{Ptr{MX_uint}}, Ref{Ptr{Ptr{MX_uint}}},
-             Ref{MX_uint}, Ref{Ptr{MX_uint}}, Ref{Ptr{Ptr{MX_uint}}},
-             Ref{Cint}),
-            self, length(indptr)-1, keys, indptr, sdata,
-            ref_arg_shape_size, ref_arg_shape_ndim, ref_arg_shape_data,
-            ref_out_shape_size, ref_out_shape_ndim, ref_out_shape_data,
-            ref_aux_shape_size, ref_aux_shape_ndim, ref_aux_shape_data,
-            ref_complete)
-    if ref_complete[] == 0
-      return (nothing, nothing, nothing)
-    else
-      function build_shapes(shape_size::MX_uint, shape_ndim::Ptr{MX_uint}, shape_data::Ptr{Ptr{MX_uint}})
-        shape_ndim = pointer_to_array(shape_ndim, shape_size)
-        shape_data = pointer_to_array(shape_data, shape_size)
-        shapes = map(1:shape_size) do i
-          my_shape = pointer_to_array(shape_data[i], shape_ndim[i])
-          tuple(flipdim(Int[my_shape...],1)...)
-        end
-        convert(Vector{Tuple}, shapes)
-      end
-      return (
-        build_shapes(ref_arg_shape_size[], ref_arg_shape_ndim[], ref_arg_shape_data[]),
-        build_shapes(ref_out_shape_size[], ref_out_shape_ndim[], ref_out_shape_data[]),
-        build_shapes(ref_aux_shape_size[], ref_aux_shape_ndim[], ref_aux_shape_data[])
-      )
-    end
+function _build_shapes(shape_size::MX_uint, shape_ndim::Ptr{MX_uint}, shape_data::Ptr{Ptr{MX_uint}})
+  shape_ndim = pointer_to_array(shape_ndim, shape_size)
+  shape_data = pointer_to_array(shape_data, shape_size)
+  shapes = map(1:shape_size) do i
+    my_shape = pointer_to_array(shape_data[i], shape_ndim[i])
+    tuple(flipdim(Int[my_shape...],1)...)
+  end
+  convert(Vector{Tuple}, shapes)
+end
+
+function _infer_shape(self, keys, indptr, sdata)
+  ref_arg_shape_size = Ref{MX_uint}(0)
+  ref_arg_shape_ndim = Ref{Ptr{MX_uint}}(0)
+  ref_arg_shape_data = Ref{Ptr{Ptr{MX_uint}}}(0)
+  ref_out_shape_size = Ref{MX_uint}(0)
+  ref_out_shape_ndim = Ref{Ptr{MX_uint}}(0)
+  ref_out_shape_data = Ref{Ptr{Ptr{MX_uint}}}(0)
+  ref_aux_shape_size = Ref{MX_uint}(0)
+  ref_aux_shape_ndim = Ref{Ptr{MX_uint}}(0)
+  ref_aux_shape_data = Ref{Ptr{Ptr{MX_uint}}}(0)
+  ref_complete       = Ref{Cint}(0)
+  @mxcall(:MXSymbolInferShape,
+          (MX_handle, MX_uint, char_pp, Ptr{MX_uint}, Ptr{MX_uint},
+           Ref{MX_uint}, Ref{Ptr{MX_uint}}, Ref{Ptr{Ptr{MX_uint}}},
+           Ref{MX_uint}, Ref{Ptr{MX_uint}}, Ref{Ptr{Ptr{MX_uint}}},
+           Ref{MX_uint}, Ref{Ptr{MX_uint}}, Ref{Ptr{Ptr{MX_uint}}},
+           Ref{Cint}),
+          self, length(indptr)-1, keys, indptr, sdata,
+          ref_arg_shape_size, ref_arg_shape_ndim, ref_arg_shape_data,
+          ref_out_shape_size, ref_out_shape_ndim, ref_out_shape_data,
+          ref_aux_shape_size, ref_aux_shape_ndim, ref_aux_shape_data,
+          ref_complete)
+  if ref_complete[] == 0
+    return (nothing, nothing, nothing)
+  else
+    return (
+      _build_shapes(ref_arg_shape_size[], ref_arg_shape_ndim[], ref_arg_shape_data[]),
+      _build_shapes(ref_out_shape_size[], ref_out_shape_ndim[], ref_out_shape_data[]),
+      _build_shapes(ref_aux_shape_size[], ref_aux_shape_ndim[], ref_aux_shape_data[])
+    )
   end
 end
 
 #=doc
 .. function::
-   infer_shape(self :: SymbolicNode; args...)
+   infer_shape(self :: SymbolicNode, args...)
    infer_shape(self :: SymbolicNode; kwargs...)
 
    Do shape inference according to the input shapes. The input shapes could be provided
@@ -302,7 +301,7 @@ function infer_shape(self :: SymbolicNode; kwargs...)
     push!(indptr, length(sdata))
   end
   keys = AbstractString[string(x[1]) for x in kwargs]
-  @_infer_shape(self, keys, indptr, sdata)
+  _infer_shape(self, keys, indptr, sdata)
 end
 function infer_shape(self :: SymbolicNode, args :: Union{Tuple, Void}...)
   sdata  = MX_uint[]
@@ -313,7 +312,7 @@ function infer_shape(self :: SymbolicNode, args :: Union{Tuple, Void}...)
     push!(indptr, length(sdata))
   end
   keys = Ptr{char_p}(0)
-  @_infer_shape(self, keys, indptr, sdata)
+  _infer_shape(self, keys, indptr, sdata)
 end
 
 #=doc

--- a/test/unittest/bind.jl
+++ b/test/unittest/bind.jl
@@ -34,24 +34,24 @@ function test_arithmetic{T <: mx.DType}(::Type{T}, uf, gf)
   out2 = copy(exec2.outputs[1])
   out3 = copy(exec3.outputs[1])
   out4 = copy(exec4.outputs[1])
-  @test reldiff(out1, out2) < 1e-6
-  @test reldiff(out1, out3) < 1e-6
-  @test reldiff(out1, out4) < 1e-6
+  @test isapprox(out1, out2)
+  @test isapprox(out1, out3)
+  @test isapprox(out1, out4)
 
   # test gradients
   out_grad = mx.NDArray(ones(T, shape))
   lhs_grad2, rhs_grad2 = gf(copy(out_grad), copy(lhs_arr), copy(rhs_arr))
   mx.backward(exec2, out_grad)
-  @test reldiff(copy(lhs_grad), lhs_grad2) < 1e-6
-  @test reldiff(copy(rhs_grad), rhs_grad2) < 1e-6
+  @test isapprox(copy(lhs_grad), lhs_grad2)
+  @test isapprox(copy(rhs_grad), rhs_grad2)
 
   # reset grads
   lhs_grad[:] = 0
   rhs_grad[:] = 0
   # compute using another binding
   mx.backward(exec4, out_grad)
-  @test reldiff(copy(lhs_grad), lhs_grad2) < 1e-6
-  @test reldiff(copy(rhs_grad), rhs_grad2) < 1e-6
+  @test isapprox(copy(lhs_grad), lhs_grad2)
+  @test isapprox(copy(rhs_grad), rhs_grad2)
 end
 
 function test_arithmetic()
@@ -59,7 +59,7 @@ function test_arithmetic()
     test_arithmetic(T, .+, (g,x,y) -> (g,g))
     test_arithmetic(T, .-, (g,x,y) -> (g,-g))
     test_arithmetic(T, .*, (g,x,y) -> (y.*g, x.*g))
-    test_arithmetic(T, ./, (g,x,y) -> (g ./ y, -x .* g ./ (y.^2)))
+    T <: Integer || test_arithmetic(T, ./, (g,x,y) -> (g ./ y, -x .* g ./ (y.^2)))
   end
 end
 

--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -44,10 +44,23 @@ function test_assign()
   array2  = mx.zeros(size(tensor))
   @test reldiff(zeros(size(tensor)), copy(array2)) < 1e-6
 
+  array3 = mx.zeros(Float16, size(tensor))
+  @test reldiff(zeros(Float16, size(tensor)), copy(array2)) < 1e-6
+
   # scalar -> NDArray assignment
   scalar    = rand()
   array2[:] = scalar
   @test reldiff(zeros(size(tensor))+scalar, copy(array2)) < 1e-6
+
+  scalar = rand(Float16)
+  array2[:] = scalar
+  @test reldiff(zeros(size(tensor))+scalar, copy(array2)) < 1e-6
+
+  scalar = rand(Float64)
+  array2[:] = scalar
+  array3[:] = scalar
+  @test reldiff(zeros(size(tensor))+scalar, copy(array2)) < 1e-6
+  @test reldiff(zeros(Float16,size(tensor))+scalar, copy(array3)) < 1e-6
 
   # NDArray -> NDArray assignment
   array[:]  = array2

--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -271,6 +271,19 @@ function test_dot()
   @test size(z) == (2, 8)
 end
 
+function test_eltype()
+  info("NDArray::eltype")
+  dims1 = (3,3)
+
+  x = mx.empty(dims1)
+  @test eltype(x) == mx.DEFAULT_DTYPE
+
+  for TF in instances(mx.TypeFlag)
+    T = mx.fromTypeFlag(TF)
+    x = mx.empty(T, dims1)
+    @test eltype(x) == T
+  end
+end
 
 ################################################################################
 # Run tests
@@ -286,6 +299,7 @@ test_gd()
 test_saveload()
 test_clip()
 test_sqrt()
+test_eltype()
 test_nd_as_jl()
 test_dot()
 

--- a/test/unittest/operator.jl
+++ b/test/unittest/operator.jl
@@ -9,7 +9,7 @@ function test_scalar_op()
   shape = rand_dims()
   info("Operator::scalar_op::dims = $shape")
 
-  data_jl  = 5ones(shape)
+  data_jl  = 5ones(Float32, shape)
   arr_data = mx.copy(data_jl, mx.cpu())
   arr_grad = mx.zeros(shape)
 


### PR DESCRIPTION
MXNet and mshadow support a range of different types. The Julia backend currently only works with Float32 and so I am hoping to extend it to support all types supported in the backend.

@pluskid Should we convert `NDArray` to `NDArray{T}` so that we get typestable methods? e.g. `getindex`...