### PR TITLE
reorder docs for io.jl and bring them into the markdown age

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 
 after_success:
   - source $TRAVIS/run_coverage.sh
+  - echo $TRAVIS_JULIA_VERSION
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("MXNet")); include(joinpath("docs", "make.jl"))'
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,4 +8,5 @@ makedocs(
 deploydocs(
   deps = Deps.pip("pygments", "mkdocs", "mkdocs-material", "python-markdown-math"),
   repo = "github.com/dmlc/MXNet.jl.git",
+  julia = "0.5",
 )

--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -3,6 +3,117 @@
 Data providers are wrappers that load external data, be it images, text, or general tensors,
 and split it into mini-batches so that the model can consume the data in a uniformed way.
 
+## AbstractDataProvider interface
+
+```@docs
+mx.AbstractDataProvider
+```
+ 
+The difference between *data* and *label* is that during training stage,
+both *data* and *label* will be feeded into the model, while during
+prediction stage, only *data* is loaded. Otherwise, they could be anything, with any names, and
+of any shapes. The provided data and label names here should match the input names in a target
+`SymbolicNode`.
+
+A data provider should also implement the Julia iteration interface, in order to allow iterating
+through the data set. The provider will be called in the following way:
+
+```julia
+for batch in eachbatch(provider)
+    data = get_data(provider, batch)
+end
+```
+
+which will be translated by Julia compiler into
+
+```julia
+state = Base.start(eachbatch(provider))
+while !Base.done(provider, state)
+    (batch, state) = Base.next(provider, state)
+    data = get_data(provider, batch)
+end
+```
+ 
+By default, `eachbatch` simply returns the provider itself, so the iterator interface
+is implemented on the provider type itself. But the extra layer of abstraction allows us to
+implement a data provider easily via a Julia `Task` coroutine. See the
+data provider defined in [the char-lstm example](tutorial/char-lstm) for an example of using coroutine to define data
+providers.
+
+The detailed interface functions for the iterator API is listed below:
+
+    Base.eltype(provider) -> AbstractDataBatch
+
+Returns the specific subtype representing a data batch. See `AbstractDataBatch`.
+* `provider::AbstractDataProvider`: the data provider.
+
+    Base.start(provider) -> AbstractDataProviderState
+
+This function is always called before iterating into the dataset. It should initialize
+the iterator, reset the index, and do data shuffling if needed.
+* `provider::AbstractDataProvider`: the data provider.
+
+    Base.done(provider, state) -> Bool
+
+True if there is no more data to iterate in this dataset.
+* `provider::AbstractDataProvider`: the data provider.
+* `state::AbstractDataProviderState`: the state returned by `Base.start` and `Base.next`.
+
+    Base.next(provider) -> (AbstractDataBatch, AbstractDataProviderState)
+
+Returns the current data batch, and the state for the next iteration.
+* `provider::AbstractDataProvider`: the data provider.
+
+Note sometimes you are wrapping an existing data iterator (e.g. the built-in libmxnet data iterator) that
+is built with a different convention. It might be difficult to adapt to the interfaces stated here. In this
+case, you can safely assume that
+
+* `Base.start` will always be called, and called only once before the iteration starts.
+* `Base.done` will always be called at the beginning of every iteration and always be called once.
+* If `Base.done` return true, the iteration will stop, until the next round, again, starting with
+  a call to `Base.start`.
+* `Base.next` will always be called only once in each iteration. It will always be called after
+  one and only one call to `Base.done`; but if `Base.done` returns true, `Base.next` will
+  not be called.
+
+With those assumptions, it will be relatively easy to adapt any existing iterator. See the implementation
+of the built-in `MXDataProvider` for example.
+
+### Note:
+Please do not use the one data provider simultaneously in two different places, either in parallel,
+or in a nested loop. For example, the behavior for the following code is undefined
+
+```julia
+for batch in data
+    # updating the parameters
+
+    # now let's test the performance on the training set
+    for b2 in data
+        # ...
+    end
+end
+```
+
+```@docs
+mx.get_batch_size
+mx.provide_data
+mx.provide_label
+```
+
+## AbstractDataBatch interface
+
+```@docs
+mx.AbstractDataProviderState
+mx.count_samples
+mx.get_data
+mx.get_label
+mx.get
+mx.load_data!
+mx.load_label!
+```
+
+## Implemented providers and other methods
+
 ```@autodocs
 Modules = [MXNet.mx]
 Pages = ["io.jl"]

--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -79,20 +79,20 @@ case, you can safely assume that
 With those assumptions, it will be relatively easy to adapt any existing iterator. See the implementation
 of the built-in `MXDataProvider` for example.
 
-### Note:
-Please do not use the one data provider simultaneously in two different places, either in parallel,
-or in a nested loop. For example, the behavior for the following code is undefined
+!!! note
+    Please do not use the one data provider simultaneously in two different places, either in parallel,
+    or in a nested loop. For example, the behavior for the following code is undefined
 
-```julia
-for batch in data
-    # updating the parameters
+    ```julia
+    for batch in data
+        # updating the parameters
 
-    # now let's test the performance on the training set
-    for b2 in data
-        # ...
+        # now let's test the performance on the training set
+        for b2 in data
+            # ...
+        end
     end
-end
-```
+    ```
 
 ```@docs
 mx.get_batch_size

--- a/src/base.jl
+++ b/src/base.jl
@@ -30,7 +30,7 @@ end
 
 function __init__()
   _populate_symbol_creator_cache!()
-  _import_io_iterators()
+  _populate_iter_creator_cache!()
 
   atexit() do
     # notify libmxnet we are shutting down

--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -241,7 +241,7 @@ import Base: size, length, ndims, eltype
    size(arr :: NDArray, dim :: Int)
 
 Get the shape of an `NDArray`. The shape is in Julia's column-major convention. See
-also the notes on NDArray shapes [`NDArrat`](@ref).
+also the notes on NDArray shapes [`NDArray`](@ref).
 """
 function size(arr :: NDArray)
   ref_ndim  = Ref{MX_uint}(0)

--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -33,13 +33,14 @@ function Base.copy(self :: SymbolicNode)
 end
 
 # TODO(vchuravy) How to add documentation to the v0.5 style call overloading
-"""
+@doc """
     call(self :: SymbolicNode, args :: SymbolicNode...)
     call(self :: SymbolicNode; kwargs...)
 
 Make a new node by composing `self` with `args`. Or the arguments
 can be specified using keyword arguments.
-"""
+""" SymbolicNode
+
 @compat function (self::SymbolicNode)(args :: SymbolicNode...)
   s = deepcopy(self)
   _compose!(s, args...)


### PR DESCRIPTION
This improves the doc situation for `io.jl`. There might be a problem with `@autodocs` and `@docs` that needs to be solved in Documenter (I am still investigating).