### PR TITLE
handle kwargs for ndarray functions

### DIFF
--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -1035,6 +1035,15 @@ function _get_function_expressions(handle :: MX_handle, name)
   if name == :dot
     _use_vars.args[2:end] = flipdim(_use_vars.args[2:end], 1)
   end
+
+  if name == :transpose
+    transform = quote
+      kwargs = Any[key != :axes ? (key, arg) : (key, reverse(map(i->length(arg)-i, arg))) for (key, arg) in kwargs]
+    end
+  else
+    transform = :()
+  end
+
   stmt_call = quote
     local handle = _get_function($(QuoteNode(name)))
     _invoke_mxfunction(handle, $_use_vars, $_scalars, $_mut_vars; kwargs...)
@@ -1047,6 +1056,7 @@ function _get_function_expressions(handle :: MX_handle, name)
 
   func_def = quote
     function $name($(args...); kwargs...)
+      $transform
       $stmt_call
       $stmt_ret
     end

--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -630,6 +630,11 @@ function _define_atomic_symbol_creator(hdr :: MX_handle)
       name = ""
     end
 
+    if $func_name == :transpose
+      kwargs = Any[key != :axes ? (key, arg) : (key, reverse(map(i->length(arg)-i, arg))) for (key, arg) in kwargs]
+    end
+
+
     param_keys = String[]
     param_vals = String[]
     symbol_kws = Dict{Symbol, SymbolicNode}()

--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -302,10 +302,12 @@ function test_kwargs()
   info("NDArray::kwargs")
   dims1 = (2,3,4)
 
-  x = mx.empty(dims1)
-  tx = mx.transpose(x, axes=(1,0,2))
-  # @test size(tx) == (3,2,4)
-  @test size(tx) == (2,4,3)
+  A = rand(Float32, dims1)
+  x = mx.NDArray(A)
+  tx = mx.transpose(x, axes=(2,1,3))
+  tA = permutedims(A, [2,1,3])
+  @test size(tx) == size(tA)
+  @test all(copy(tx) .== tA)
 end
 
 ################################################################################

--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -298,6 +298,16 @@ function test_eltype()
   end
 end
 
+function test_kwargs()
+  info("NDArray::kwargs")
+  dims1 = (2,3,4)
+
+  x = mx.empty(dims1)
+  tx = mx.transpose(x, axes=(1,0,2))
+  # @test size(tx) == (3,2,4)
+  @test size(tx) == (2,4,3)
+end
+
 ################################################################################
 # Run tests
 ################################################################################
@@ -315,5 +325,6 @@ test_sqrt()
 test_eltype()
 test_nd_as_jl()
 test_dot()
+test_kwargs()
 
 end


### PR DESCRIPTION
this fixes #120 

This is similar to how python handles things, but it doesn't allow us to handle miss-typed kwargs gracefully.

@pluskid For transpose we might need to do some more work, since the expected order and axis's ids are in python order and not Julia order (thus backwards...)