### PR TITLE
BUG: fix two small mistakes with verbosity control

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -522,7 +522,7 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
 
     time_stop = time()
     metric = get(opts.eval_metric)
-    opts.verbosity >= 2 && info(format("== Epoch {1:0>3d}/{1:0>3d} ==========", i_epoch, opts.n_epoch))
+    opts.verbosity >= 2 && info(format("== Epoch {1:0>3d}/{2:0>3d} ==========", i_epoch, opts.n_epoch))
     if opts.verbosity >= 3
         info("## Training summary")
         for (name, value) in metric
@@ -579,6 +579,7 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
   end # end of all epochs
 
   opts.verbosity >= 1 && info("Finish training on $(self.ctx)")
+  nothing
 end
 
 function save_checkpoint(self :: FeedForward, prefix :: AbstractString, state :: OptimizationState)


### PR DESCRIPTION
I realized that my previous PR left two small mistakes:

- when printing epoch numbers I was doing "i_epoch/i_epoch" instead of "i_epoch/n_epoch"
- if verbosity was 0 the return value of `mx.fit` was `false`, otherwise it was an implicit nothing -- now it is always nothing.