### PR TITLE
Update build.jl to support windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,11 +24,18 @@ if !libmxnet_detected
   ################################################################################
   # If not found, try to build automatically using BinDeps
   ################################################################################
-  if is_windows()
-    info("Please follow the libmxnet documentation on how to build manually")
-    info("or to install pre-build packages:")
-    info("http://mxnet.readthedocs.io/en/latest/how_to/build.html#building-on-windows")
-    error("Automatic building libxmnet on Windows is currently not supported yet.")
+  if is_windows()  
+	DOWNLOAD_URL = "https://github.com/dmlc/mxnet/releases/download/20160531/20160531_win10_x64_cpu.7z"
+	run(download_cmd(DOWNLOAD_URL, "mxnet.7z"))
+	run(`7z x mxnet.7z -y -ousr`)
+	run(`usr\\setupenv.cmd`)
+	run(`cmd /c copy "usr\\3rdparty\\openblas\\bin\\*.dll" "usr\\lib"`)
+	
+	DOWNLOAD_URL = "https://github.com/yajiedesign/mxnet/releases/download/20161125/20161125_mxnet_x64_cpu.7z"
+	run(download_cmd(DOWNLOAD_URL, "mxnet.7z"))
+	run(`7z x mxnet.7z -y -ousr`)
+
+	return
   end
 
   blas_path = Libdl.dlpath(Libdl.dlopen(Base.libblas_name))


### PR DESCRIPTION
Here are the changes to support windows. With this `Pkg.build("MXNet")` should work. Since the version https://github.com/dmlc/mxnet/releases/tag/20160531 does not include the changes in https://github.com/yajiedesign/mxnet/releases/tag/20161125, the download is being performed twice. Let me know if there is a better way to address this.