### PR TITLE
Medium and High Level api for SymbolModule

### DIFF
--- a/src/executor-group.jl
+++ b/src/executor-group.jl
@@ -180,14 +180,15 @@ function backward(self::DataParallelExecutorGroup, out_grads::Vector{NDArray})
 end
 
 """
-		set_params!(self::DataParallelExecutorGroup, arg_params, aux_params)
+		set_params!(self::DataParallelExecutorGroup, arg_params, aux_params; allow_extra_params)
 
 Assign, i.e. copy parameters to all the executors.
 # Arguments
-* `arg_params` : Dict{Symbol, NDArray}
+* `arg_params` : `Dict{Symbol, NDArray}`
   A dictionary of name to `NDArray` parameter mapping.
-* `aux_params` : Dict{Symbol, NDArray}
+* `aux_params` : `Dict{Symbol, NDArray}`
   A dictionary of name to `NDArray` auxiliary variable mapping.
+* `allow_extra_params`: `Bool`, default `false`, allow parameters in `arg_params` or `aux_params` that not exists in `self`.
 """
 function set_params!(self::DataParallelExecutorGroup,
                     arg_params, aux_params; allow_extra_params::Bool = false)
@@ -315,15 +316,15 @@ function get_outputs(self::DataParallelExecutorGroup, merge_multi_context::Bool=
     return outputs
   end
 end
+
+function output_shapes(self:: DataParallelExecutorGroup)
+  outputs = [size(out) for out in self.execs[1].outputs]
+  return Dict(key => shape for (key, shape) in zip(list_outputs(self.symbol), outputs))
+end
+
 ##
 # Internals
 ##
-
-
-function output_shapes(self:: DataParallelExecutorGroup)
-  #= outputs = [size(out) for out in self.execs[1].outputs] =#
-  #= return [tuple(key, shape) for key, shape in zip(list_outputs(exec_group.symbol), outputs)] =#
-end
 
 function get_grads(symbol, param_names, arg_names, data_names, inputs_need_grad, fixed_param_names, grad_req)
   if isnull(fixed_param_names)

--- a/src/io.jl
+++ b/src/io.jl
@@ -17,6 +17,9 @@ Normally this involves defining:
 """
 abstract AbstractDataProvider
 
+type StubProvider <: AbstractDataProvider
+end
+
 """
     get_batch_size(provider) -> Int
 
@@ -124,9 +127,6 @@ get_label{Provider<:AbstractDataProvider}(::Provider, batch :: DataBatch) = batc
 
 type DataBatchProvider <: AbstractDataProvider
   provider :: AbstractDataProvider
-
-  DataBatchProvider() = new()
-  DataBatchProvider(provider) = new(provider)
 end
 
 eachdatabatch(provider :: AbstractDataProvider) = DataBatchProvider(provider)

--- a/src/module/symbol_module.jl
+++ b/src/module/symbol_module.jl
@@ -289,11 +289,11 @@ Forward computation.
 
 # Arguments
 * `data_batch` : AbstractDataBatch
-* `is_train` : Nullable{Bool}
+* `is_train` : Bool
   Default is `nothing`, which means `is_train` takes the value of `self.for_training`.
 """
-forward(self::SymbolModule, data_provider :: AbstractDataProvider, data_batch :: AbstractDataBatch, is_train = nothing) = forward(self, data_provider, data_batch, Nullable{Bool}(is_train))
-function forward(self::SymbolModule, data_provider :: AbstractDataProvider, data_batch :: AbstractDataBatch, is_train::Nullable{Bool})
+forward(self::SymbolModule, data_batch::DataBatch) = forward(self, StubProvider(), data_batch, self.for_training)
+function forward(self::SymbolModule, data_provider :: AbstractDataProvider, data_batch :: AbstractDataBatch, is_train::Bool)
   @assert isbinded(self) && isinitialized(self)
   mx.forward(self.exec_group, data_provider, data_batch, is_train)
 end

--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -682,7 +682,22 @@ function /(arg0 :: NDArray, arg :: Real)
   ./(arg0, arg)
 end
 
-function concatenate(arrays::Vector{NDArray}; always_copy=true)
+"""
+    concatenate(arrays; always_copy=true, context=cpu)
+
+Concatenate a list of NDArrays along the last dimension.
+
+# Arguments
+* `arrays` : vector of NDArray
+  Arrays to be concatenate. They must have identical shape except
+  the last dimension. 
+* `always_copy` : `Bool`, default `true`. When `false`, if the arrays only contain one `NDArray`, that element will be returned directly, avoid copying.
+* `context`: `Context`, context of output NDArray.
+
+# Returns
+An `NDArray` that lives on the `context`.
+"""
+function concatenate(arrays::Vector{NDArray}; always_copy=true, context=cpu())
   if isempty(arrays) || (!always_copy && length(arrays) == 1)
     return arrays
   end
@@ -695,12 +710,11 @@ function concatenate(arrays::Vector{NDArray}; always_copy=true)
   end
   
   ret_shape = tuple(shape_rest..., shape_axis)
-  ret = empty(ret_shape, context(arrays[1]))
+  ret = empty(ret_shape, context)
 
   idx = 1
   for arr in arrays
-    setindex!(ret, arr, idx:idx+size(arr)[end])
-    #= ret[idx:idx + size(arr)[end]] = arr =#
+    ret[idx:(idx + size(arr)[end] - 1)] = arr
     idx += size(arr)[end]
   end
 

--- a/test/unittest/symbol-module.jl
+++ b/test/unittest/symbol-module.jl
@@ -91,10 +91,10 @@ function test_linear_regression(n_epoch::Int = 10)
   for i in 1:n_epoch
     for batch in mx.eachdatabatch(data)
       mx.Module.forward(m1, batch)
-      mx.Module.update_metric(m1, metric, batch)
-
       mx.Module.backward(m1)
       mx.Module.update(m1)
+
+      mx.Module.update_metric(m1, metric, batch)
     end
 
     for (name, value) in get(metric)
@@ -121,6 +121,16 @@ function test_linear_regression(n_epoch::Int = 10)
   info("Score $name     : ", score)
   
   @test sum(abs(ha_pred-y_pred)) < 1e-6
+
+  m2 = mx.Module.SymbolModule(create_linreg(4), 
+                              label_names = [:linout_label],
+                              context=[mx.cpu(), mx.cpu()])
+  mx.Module.fit(m2, data, 10, eval_metric=mx.MSE())
+  name, score = mx.Module.score(m2, data, metric)[1]
+  ha_pred = mx.copy(mx.Module.predict(m2, data))
+  info("Predict result: ", ha_pred)
+  info("Score $name     : ", score)
+  @test sum(abs(ha_pred-y_pred)) < 1e-1
 end
 
 ################################################################################

--- a/test/unittest/symbol-module.jl
+++ b/test/unittest/symbol-module.jl
@@ -2,23 +2,25 @@ module TestSymbolModule
 using MXNet
 using Base.Test
 
+using ..Main: reldiff
+
 ################################################################################
 # Utils
 ################################################################################
 
 function create_network()
   arch = mx.@chain mx.Variable(:data) =>
-         mx.Convolution(kernel = (3,3), pad = (1,1), stride = (1,1), num_filter = 64) =>
-         mx.SoftmaxOutput(name=:softmax, multi_output = true)
+  mx.Convolution(kernel = (3,3), pad = (1,1), stride = (1,1), num_filter = 64) =>
+  mx.SoftmaxOutput(name=:softmax, multi_output = true)
 
   return arch
 end
 
 function create_linreg(num_hidden::Int=1)
   arch = @mx.chain mx.Variable(:data) =>
-         mx.FullyConnected(name=:fc1, num_hidden=num_hidden) =>
-         mx.FullyConnected(name=:fc2, num_hidden=1) =>
-         mx.LinearRegressionOutput(name=:linout)
+  mx.FullyConnected(name=:fc1, num_hidden=num_hidden) =>
+  mx.FullyConnected(name=:fc2, num_hidden=1) =>
+  mx.LinearRegressionOutput(name=:linout)
   return arch
 end
 
@@ -28,7 +30,7 @@ end
 
 function test_basic()
   info("SymbolModule::basic")
-  
+
   m1 = mx.Module.SymbolModule(create_network())
 
   @test !mx.Module.isbinded(m1)
@@ -38,8 +40,8 @@ function test_basic()
 
   @test mx.Module.data_names(m1) == [:data]
   @test mx.Module.output_names(m1) == [:softmax_output]
-  
-  mx.Module.bind(m1, [(20, 20, 1, 10)], [(20, 20, 1, 10)])
+
+  mx.Module.bind(m1, [(20, 20, 1, 10)], [(400, 10)])
   @test mx.Module.isbinded(m1)
   @test !mx.Module.isinitialized(m1)
   @test !mx.Module.hasoptimizer(m1)
@@ -51,11 +53,24 @@ function test_basic()
   @test mx.Module.hasoptimizer(m1)
 end
 
-function test_init_params(n_epoch::Int = 10)
-  info("SymbolModule::InitParams")
+function test_shapes()
+  info("SymbolModule::Shapes")
 
-  #= x = reshape(collect(1:10), (1, 10)) =#
-  #= y = reshape(collect(2:11), (1, 10)) =#
+  m1 = mx.Module.SymbolModule(create_network())
+  mx.Module.bind(m1, [(20, 20, 1, 10)], [(20, 20, 1, 10)])
+
+  @test mx.Module.data_shapes(m1) == Dict(:data => (20, 20, 1, 10))
+  @test mx.Module.label_shapes(m1) == Dict(:softmax_label => (20, 20, 1, 10))
+  @test mx.Module.output_shapes(m1) == Dict(:softmax_output => (20, 20, 64, 10))
+
+  m2 = mx.Module.SymbolModule(create_network(), label_names=[])
+  mx.Module.bind(m2, [(20, 20, 1, 10)])
+  @test isempty(mx.Module.label_shapes(m2))
+end
+
+function test_linear_regression(n_epoch::Int = 10)
+  info("SymbolModule::LinearRegression")
+
   srand(123456)
   epsilon = randn(1, 10)
   x = rand(4, 10)
@@ -90,13 +105,22 @@ function test_init_params(n_epoch::Int = 10)
 
   y_pred = Float64[]
   for batch in mx.eachdatabatch(data)
-    mx.Module.forward(m1, batch)
+    mx.Module.forward(m1, batch, false)
     append!(y_pred, Array{Float64}(mx.Module.get_outputs(m1)[1]))
   end
+  y_pred = reshape(y_pred, 1, 10)
 
   info("Prediction: $y_pred")
   info("Actual:     $y")
   info("No noise:   $(mapslices(sum, [1, 2, 3, 4] .* x, 1))")
+
+  # High Level Api
+  name, score = mx.Module.score(m1, data, metric)[1]
+  ha_pred = mx.copy(mx.Module.predict(m1, data))
+  info("Predict result: ", ha_pred)
+  info("Score $name     : ", score)
+  
+  @test sum(abs(ha_pred-y_pred)) < 1e-6
 end
 
 ################################################################################
@@ -105,7 +129,9 @@ end
 
 @testset "Symbol Module Test" begin
   test_basic()
-  test_init_params(500)
+  test_shapes()
+  #= test_init_params(500) =#
+  test_linear_regression()
 end
 
 end

--- a/test/unittest/symbol-module.jl
+++ b/test/unittest/symbol-module.jl
@@ -14,9 +14,9 @@ function create_network()
   return arch
 end
 
-function create_single_neuron()
+function create_linreg(num_hidden::Int=1)
   arch = @mx.chain mx.Variable(:data) =>
-         mx.FullyConnected(name=:fc1, num_hidden=1) =>
+         mx.FullyConnected(name=:fc1, num_hidden=num_hidden) =>
          mx.LinearRegressionOutput(name=:linout)
   return arch
 end
@@ -52,19 +52,28 @@ end
 
 function test_init_params()
   info("SymbolModule::InitParams")
-  m1 = mx.Module.SymbolModule(create_single_neuron(), 
-                              label_names = [:linout_label])
-  mx.Module.bind(m1, [(1, 10)], [(1, 10)])
+
+  #= x = reshape(collect(1:10), (1, 10)) =#
+  #= y = reshape(collect(2:11), (1, 10)) =#
+  srand(123456)
+  epsilon = rand(1, 10)
+  x = rand(4, 10)
+  y = 2*x .+ epsilon
+  data = mx.ArrayDataProvider(:data => x, :linout_label => y; batch_size = 5)
+
+  m1 = mx.Module.SymbolModule(create_linreg(4), 
+                              label_names = [:linout_label],
+                              context=[mx.cpu(), mx.cpu()])
+  mx.Module.bind(m1, data)
   mx.Module.init_params(m1)
+  mx.Module.init_optimizer(m1)
 
   # TODO Should be changed to tests
-  info(mx.Module.get_params(m1))
+  #= info(mx.Module.get_params(m1)) =#
 
-  x = reshape(collect(1:10), (1, 10))
-  y = reshape(collect(2:11), (1, 10))
-  data = mx.ArrayDataProvider(:data => x, :linout_label => y; batch_size = 10)
   for batch in mx.eachdatabatch(data)
     mx.Module.forward(m1, batch)
+    info("SymbolModule::InitParams: $(copy(mx.Module.get_outputs(m1)[1]))")
     mx.Module.backward(m1)
     mx.Module.update(m1)
   end

--- a/test/unittest/symbol-module.jl
+++ b/test/unittest/symbol-module.jl
@@ -65,6 +65,8 @@ function test_init_params()
   data = mx.ArrayDataProvider(:data => x, :linout_label => y; batch_size = 10)
   for batch in mx.eachdatabatch(data)
     mx.Module.forward(m1, batch)
+    mx.Module.backward(m1)
+    mx.Module.update(m1)
   end
 end
 


### PR DESCRIPTION
Implemented medium and high level api, examples (linear regression) in unittest/symbol-module.jl

Not implemented:
1. Callbacks in `fit`, `score`
2. `KVStore` support, right now kvstore defaults to `nothing`.
3. `reset` in `fit`, `score`, because it involves rewriting of `AbstractDataProvider`

Problems:
1. Tests coverage is very low
2. Docs is a mess. Some style guides needed
3. Code should be cleaned: fields in types should contain definitions, function definitions can be improved.
4. Due to 1. it probably contains some unexpected bugs.

I am switching now to the implementation of `SequentialModule`, because it will be useful in checking `grad_outputs`.