### PR TITLE
Disable Travis testing on v0.6 until #170 is addressed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - osx
 julia:
   - 0.5
-  - nightly
+#  - nightly 0.6 supports depends on #170
 
 # dependent apt packages
 addons:

--- a/examples/char-lstm/seq-data.jl
+++ b/examples/char-lstm/seq-data.jl
@@ -5,7 +5,7 @@ using MXNet
 function build_vocabulary(corpus_fn::AbstractString, vocab_fn::AbstractString; max_vocab=10000)
   if isfile(vocab_fn)
     info("Vocabulary already exists, reusing $vocab_fn...")
-    vocab = Dict{Char,Int}([w => i for (i,w) in enumerate(readall(vocab_fn))])
+    vocab = Dict{Char,Int}([w => i for (i,w) in enumerate(readstring(vocab_fn))])
   else
     # count symbol frequency
     dict = Dict{Char,Int}()

--- a/examples/char-lstm/train.jl
+++ b/examples/char-lstm/train.jl
@@ -14,7 +14,7 @@ lstm = LSTM(LSTM_N_LAYER, SEQ_LENGTH, DIM_HIDDEN, DIM_EMBED,
 
 #--data
 # load data
-text_all  = readall(INPUT_FILE)
+text_all  = readstring(INPUT_FILE)
 len_train = round(Int, length(text_all)*DATA_TR_RATIO)
 text_tr   = text_all[1:len_train]
 text_val  = text_all[len_train+1:end]

--- a/examples/mnist/mlp-test.jl
+++ b/examples/mnist/mlp-test.jl
@@ -5,6 +5,8 @@ module MNISTTest
 using MXNet
 using Base.Test
 
+include("mnist-data.jl")
+
 function get_mnist_mlp()
   mlp = @mx.chain mx.Variable(:data)             =>
     mx.FullyConnected(name=:fc1, num_hidden=128) =>
@@ -17,7 +19,6 @@ function get_mnist_mlp()
 end
 
 function get_mnist_data(batch_size=100)
-  include("mnist-data.jl")
   return get_mnist_providers(batch_size)
 end
 

--- a/examples/mnist/mlp-test.jl
+++ b/examples/mnist/mlp-test.jl
@@ -41,7 +41,7 @@ function mnist_fit_and_predict(optimizer, initializer, n_epoch)
   end
   mlp_load = mx.load("$cp_prefix-symbol.json", mx.SymbolicNode)
   @test mx.to_json(mlp_load) == mx.to_json(mlp)
-  mlp_load = mx.from_json(readall("$cp_prefix-symbol.json"), mx.SymbolicNode)
+  mlp_load = mx.from_json(readstring("$cp_prefix-symbol.json"), mx.SymbolicNode)
   @test mx.to_json(mlp_load) == mx.to_json(mlp)
 
   #--------------------------------------------------------------------------------

--- a/src/MXNet.jl
+++ b/src/MXNet.jl
@@ -11,6 +11,10 @@ using Compat
 import Compat.String
 import Compat.view
 
+if VERSION >= v"0.6.0-dev.1024"
+  import Base.Iterators: filter
+end
+
 using Formatting
 
 # Functions from base that we can safely extend and that are defined by libmxnet.

--- a/src/model.jl
+++ b/src/model.jl
@@ -389,7 +389,7 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
     end
   end
 
-  train_execs = Array(Executor, num_dev)
+  train_execs = Array{Executor}(num_dev)
   for i = 1:num_dev
     data_shapes = Dict(map((x) -> x[1] => tuple(x[2][1:end-1]...,length(slices[i])), provide_data(data)))
     label_shapes = Dict(map((x) -> x[1] => tuple(x[2][1:end-1]...,length(slices[i])), provide_label(data)))

--- a/test/unittest/kvstore.jl
+++ b/test/unittest/kvstore.jl
@@ -62,7 +62,7 @@ function test_aggregator()
 
   for vv in vals
     for v in vv
-      @test maximum(abs(copy(v)) - 2num_devs) == 0
+      @test maximum(abs.(copy(v)) - 2 * num_devs) == 0
     end
   end
 end


### PR DESCRIPTION
We currently don't handle broadcasting gracefully and while I originally thought that we are just missing out on broadcasting functionality, it turns out that the deprecation of `.+` etc breaks a lot more code than expected.

This should turn Travis green again.