### PR TITLE
Fix for symbolic node

### DIFF
--- a/examples/char-lstm/sampler.jl
+++ b/examples/char-lstm/sampler.jl
@@ -10,11 +10,11 @@ vocab   = build_vocabulary(INPUT_FILE, VOCAB_FILE)
 n_class = length(vocab)
 
 # prepare data provider
-jl_data = Pair[(symbol(NAME, "_data_$t") => zeros(mx.MX_float, (length(vocab), BATCH_SIZE_SMP)))
+jl_data = Pair[(Symbol(NAME, "_data_$t") => zeros(mx.MX_float, (length(vocab), BATCH_SIZE_SMP)))
                for t = 1:1]
-jl_c    = Pair[(symbol(NAME, "_l$(l)_init_c") => zeros(mx.MX_float, (DIM_HIDDEN, BATCH_SIZE_SMP)))
+jl_c    = Pair[(Symbol(NAME, "_l$(l)_init_c") => zeros(mx.MX_float, (DIM_HIDDEN, BATCH_SIZE_SMP)))
                for l = 1:LSTM_N_LAYER]
-jl_h    = Pair[(symbol(NAME, "_l$(l)_init_h") => zeros(mx.MX_float, (DIM_HIDDEN, BATCH_SIZE_SMP)))
+jl_h    = Pair[(Symbol(NAME, "_l$(l)_init_h") => zeros(mx.MX_float, (DIM_HIDDEN, BATCH_SIZE_SMP)))
                for l = 1:LSTM_N_LAYER]
 
 # the first input in the sequence
@@ -36,7 +36,7 @@ output_samples = zeros(Char, (SAMPLE_LENGTH, BATCH_SIZE_SMP))
 output_samples[1, :] = SAMPLE_START
 
 # build inverse vocabulary for convenience
-inv_vocab = Dict([v => k for (k,v) in vocab])
+inv_vocab = Dict(v => k for (k,v) in vocab)
 
 # do prediction and sampling step by step
 for t = 2:SAMPLE_LENGTH-1

--- a/examples/char-lstm/seq-data.jl
+++ b/examples/char-lstm/seq-data.jl
@@ -5,7 +5,7 @@ using MXNet
 function build_vocabulary(corpus_fn::AbstractString, vocab_fn::AbstractString; max_vocab=10000)
   if isfile(vocab_fn)
     info("Vocabulary already exists, reusing $vocab_fn...")
-    vocab = Dict{Char,Int}([w => i for (i,w) in enumerate(readstring(vocab_fn))])
+    vocab = Dict{Char,Int}(w => i for (i,w) in enumerate(readstring(vocab_fn)))
   else
     # count symbol frequency
     dict = Dict{Char,Int}()
@@ -25,7 +25,7 @@ function build_vocabulary(corpus_fn::AbstractString, vocab_fn::AbstractString; m
       end
     end
 
-    vocab = Dict([x.first => i for (i,x) in enumerate(vocab)])
+    vocab = Dict(x.first => i for (i,x) in enumerate(vocab))
   end
   vocab[UNKNOWN_CHAR] = length(vocab)
   return vocab
@@ -50,12 +50,12 @@ end
 
 #--provide
 function mx.provide_data(p :: CharSeqProvider)
-  [(symbol(p.prefix, "_data_$t"), (length(p.vocab), p.batch_size)) for t = 1:p.seq_len] ∪
-  [(symbol(p.prefix, "_l$(l)_init_c"), (p.dim_hidden, p.batch_size)) for l=1:p.n_layer] ∪
-  [(symbol(p.prefix, "_l$(l)_init_h"), (p.dim_hidden, p.batch_size)) for l=1:p.n_layer]
+  [(Symbol(p.prefix, "_data_$t"), (length(p.vocab), p.batch_size)) for t = 1:p.seq_len] ∪
+  [(Symbol(p.prefix, "_l$(l)_init_c"), (p.dim_hidden, p.batch_size)) for l=1:p.n_layer] ∪
+  [(Symbol(p.prefix, "_l$(l)_init_h"), (p.dim_hidden, p.batch_size)) for l=1:p.n_layer]
 end
 function mx.provide_label(p :: CharSeqProvider)
-  [(symbol(p.prefix, "_label_$t"), (p.batch_size,)) for t = 1:p.seq_len]
+  [(Symbol(p.prefix, "_label_$t"), (p.batch_size,)) for t = 1:p.seq_len]
 end
 #--/provide
 

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -259,7 +259,7 @@ function normalized_gradient(opts::AbstractOptimizerOptions, state::Optimization
 
   grad = grad_scale * grad
   if opts.grad_clip > 0
-    grad = clip(grad, -opts.grad_clip, opts.grad_clip)
+    grad = clip(grad, a_min=-opts.grad_clip, a_max=opts.grad_clip)
   end
   if opts.weight_decay > 0
     @inplace grad += opts.weight_decay * weight

--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -680,7 +680,7 @@ function _define_atomic_symbol_creator(name :: String)
       set_attr(node, k, v)
     end
 
-    if length(args) > 1
+    if length(symbol_kws) == 0
       _compose!(node, name, args...)
     elseif length(args) == 1
       _compose!(node; name=name, data=args[1], symbol_kws...)

--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -650,8 +650,8 @@ function _define_atomic_symbol_creator(name :: String)
       end
     end
 
-    if length(args) != 0 && length(symbol_kws) != 0
-      @assert(false, $name * " only accepts SymbolicNode either as positional or keyword arguments, not both.")
+    if length(args) > 1 && length(symbol_kws) != 0
+      @assert(false, $name * " only accepts SymbolicNode either as positional or keyword arguments with optional positional `data` argument, not both.")
     end
     $(if key_narg != ""
       quote
@@ -680,9 +680,11 @@ function _define_atomic_symbol_creator(name :: String)
       set_attr(node, k, v)
     end
 
-    if length(args) != 0
+    if length(args) > 1
       _compose!(node, name, args...)
-    else
+    elseif length(args) == 1
+      _compose!(node; name=name, data=args[1], symbol_kws...)
+		else
       _compose!(node; name=name, symbol_kws...)
     end
 

--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -684,7 +684,7 @@ function _define_atomic_symbol_creator(name :: String)
       _compose!(node, name, args...)
     elseif length(args) == 1
       _compose!(node; name=name, data=args[1], symbol_kws...)
-		else
+    else
       _compose!(node; name=name, symbol_kws...)
     end
 


### PR DESCRIPTION
This is fix of symbolic node inspired by issue https://github.com/dmlc/MXNet.jl/issues/197.

The main idea is that all SymbolicNode operators which require positional arguments do not have keyword arguments that uses SymbolicNode:
* `Crop`
* `Concat`
* `ElementWiseSum`
* `UpSampling`
* arithmetic operations

All other operators have `data` as one of the arguments and this is the only argument that is used as positional, in `@mx.chain` for example.

Also removed some deprecation warnings and fixed bug in `optimizer`