### PR TITLE
Improvements to metrices

### DIFF
--- a/src/MXNet.jl
+++ b/src/MXNet.jl
@@ -16,6 +16,7 @@ if VERSION >= v"0.6.0-dev.1024"
 end
 
 using Formatting
+using Base.Threads
 
 # Functions from base that we can safely extend and that are defined by libmxnet.
 import Base: round, ceil, floor, cos, sin, abs, sign, exp, sqrt, exp, log, norm,

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,4 +1,21 @@
 ################################################################################
+# Multithreaded work load
+################################################################################
+function __threaded_reduction{F<:Function}(work::F, N, args...)
+  NT = nthreads()
+
+  # split range
+  slice = ceil(Int, N / NT)
+  results = Base.zeros(Float64, NT)
+  @threads for threadid in 1:NT
+    low = ((threadid - 1) * slice) + 1
+    high = min(N, threadid * slice)
+    results[threadid] = work(low, high, args...)
+  end
+  return sum(results)
+end
+
+################################################################################
 # Dataset related utilities
 ################################################################################
 function get_data_dir()


### PR DESCRIPTION
Depends on dmlc/mxnet#5629. Series of fixes improving metrices.
* Introduction of `SeqMetric` and `NullMetric`. `SeqMetric` splits the the outputs of the network and `NullMetric`
* Improve MSE to handle multidimensional data
* Introduce threaded reduction for MSE and ACE drastically speeding up calculations

Important to note is that `nd_as_jl` introduced type-instabilities and moving it across a function barriers allows Julia to infer the function properly.