### PR TITLE
Async prefetching and loading 

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -61,6 +61,20 @@ macro mxcall(fv, argtypes, args...)
   end
 end
 
+"Utility macro to @threadcall MXNet API functions"
+macro mxthreadcall(fv, argtypes, args...)
+  f = eval(fv)
+  args = map(esc, args)
+  quote
+    _mxret = Base.@threadcall( ($(Meta.quot(f)), $MXNET_LIB),
+                    Cint, $argtypes, $(args...) )
+    if _mxret != 0
+      err_msg = mx_get_last_error()
+      throw(MXError(err_msg))
+    end
+  end
+end
+
 ################################################################################
 # Handle types
 ################################################################################

--- a/src/io.jl
+++ b/src/io.jl
@@ -132,9 +132,9 @@ typealias SlicedNDArray Tuple{UnitRange{Int},NDArray}
 function _load_general!(provider :: AbstractDataProvider, batch :: AbstractDataBatch,
                         targets :: Vector{Vector{SlicedNDArray}}, loader::Function)
   data = loader(provider, batch)
-  for (d_src, d_targets) in zip(data, targets)
+  @sync for (d_src, d_targets) in zip(data, targets)
     for (slice_idx, d_dst) in d_targets
-      copy!(d_dst, slice(d_src, slice_idx))
+      @async copy!(d_dst, slice(d_src, slice_idx))
     end
   end
 end
@@ -176,13 +176,13 @@ function load_label!(provider :: AbstractDataProvider, batch :: AbstractDataBatc
 end
 
 function load_data!(provider :: AbstractDataProvider, batch :: AbstractDataBatch, targets :: Vector{NDArray})
-  for (src, dst) in zip(get_data(provider, batch), targets)
-    copy!(dst, src)
+  @sync for (src, dst) in zip(get_data(provider, batch), targets)
+    @async copy!(dst, src)
   end
 end
 function load_label!(provider :: AbstractDataProvider, batch :: AbstractDataBatch, targets :: Vector{NDArray})
-  for (src, dst) in zip(get_label(provider, batch), targets)
-    copy!(dst, src)
+  @sync for (src, dst) in zip(get_label(provider, batch), targets)
+    @async copy!(dst, src)
   end
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -520,8 +520,9 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
       update!(opts.eval_metric, cpu_label_arrays, cpu_output_arrays)
     end # end of one epoch
 
-    time_stop = time()
     metric = get(opts.eval_metric)
+
+    time_stop = time()
     opts.verbosity >= 2 && info(format("== Epoch {1:0>3d}/{2:0>3d} ==========", i_epoch, opts.n_epoch))
     if opts.verbosity >= 3
         info("## Training summary")

--- a/src/model.jl
+++ b/src/model.jl
@@ -462,8 +462,10 @@ function fit(self :: FeedForward, optimizer :: AbstractOptimizer, data :: Abstra
     _invoke_callbacks(self, opts.callbacks, op_state, AbstractBatchCallback)
 
     for batch in eachbatch(data)
-      load_data!(data, batch, data_arrays)
-      load_label!(data, batch, label_arrays)
+      @sync begin
+        @async load_data!(data, batch, data_arrays)
+        @async load_label!(data, batch, label_arrays)
+      end
 
       # forward and backward
       for (texec, islice) in zip(train_execs, slices)

--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -416,7 +416,7 @@ end
 function copy!{T<:DType}(dst :: Array{T}, src :: NDArray)
   @assert T == eltype(src)
   @assert size(dst) == size(src)
-  @mxcall(:MXNDArraySyncCopyToCPU, (MX_handle, Ptr{Void}, Csize_t),
+  @mxthreadcall(:MXNDArraySyncCopyToCPU, (MX_handle, Ptr{Void}, Csize_t),
           src, pointer(dst), length(dst))
   return dst
 end
@@ -428,7 +428,7 @@ function copy!{T<:Real}(dst :: NDArray, src :: Array{T})
   @assert dst.writable
   @assert size(dst) == size(src)
   src = convert(Array{eltype(dst)}, src) # this might involve copying
-  @mxcall(:MXNDArraySyncCopyFromCPU, (MX_handle, Ptr{Void}, Csize_t),
+  @mxthreadcall(:MXNDArraySyncCopyFromCPU, (MX_handle, Ptr{Void}, Csize_t),
           dst.handle, pointer(src), length(src))
   return dst
 end
@@ -437,7 +437,7 @@ function copy_ignore_shape!{T<:Real}(dst :: NDArray, src :: Array{T})
   @assert dst.writable
   @assert length(dst) == length(src)
   src = convert(Array{eltype(dst)}, src) # this might involve copying
-  @mxcall(:MXNDArraySyncCopyFromCPU, (MX_handle, Ptr{Void}, Csize_t),
+  @mxthreadcall(:MXNDArraySyncCopyFromCPU, (MX_handle, Ptr{Void}, Csize_t),
           dst.handle, pointer(src), length(src))
   return dst
 end


### PR DESCRIPTION
This uses Julia tasks to preload (currently) 4 batches onto the device.

`@threadcall` is a normal `ccall` that does not block the main Julia thread. 

```
help?> @threadcall
  @threadcall((cfunc, clib), rettype, (argtypes...), argvals...)

  The @threadcall macro is called in the same way as ccall but does the work in a different thread. This is useful
  when you want to call a blocking C function without causing the main julia thread to become blocked. Concurrency is
  limited by size of the libuv thread pool, which defaults to 4 threads but can be increased by setting the
  UV_THREADPOOL_SIZE environment variable and restarting the julia process.

  Note that the called function should never call back into Julia.
```