### PR TITLE
Use `Sys.CPU_CORES` not `nprocs()` when doing a parallel `make`

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -168,9 +168,9 @@ if !libmxnet_detected
           ChangeDirectory(_mxdir)
           `cp ../../cblas.h include/cblas.h`
           if USE_JULIA_BLAS
-            `make -j$(nprocs()) USE_BLAS=$blas_name $MSHADOW_LDFLAGS`
+            `make -j$(min(Sys.CPU_CORES,8)) USE_BLAS=$blas_name $MSHADOW_LDFLAGS`
           else
-            `make -j$(nprocs())`
+            `make -j$(min(Sys.CPU_CORES,8))`
           end
         end
         FileRule(joinpath(_libdir, "libmxnet.so"), @build_steps begin


### PR DESCRIPTION
This was always passing `-j1`, and after building this package a few times today, I'd really like it to use all my cores.  :)