### PR TITLE
Add extra check on CUDA library detection

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -36,7 +36,7 @@ end
 
 HAS_CUDA = false
 let cudalib = Libdl.find_library(["libcuda", "nvcuda.dll"], CUDAPATHS)
-  HAS_CUDA = Libdl.dlopen_e(cudalib) != C_NULL
+  HAS_CUDA = !isempty(cudalib) && Libdl.dlopen_e(cudalib) != C_NULL
 end
 
 if !HAS_CUDA && is_windows()


### PR DESCRIPTION
Some machines return a non-zero pointer for `Libdl.dlopen("")` causing
MXNet dep build to incorrectly report presence of CUDA libraries.

This is possibly a bug in Julia - I'm not sure where the non-NULL pointer goes :)