### PR TITLE
build: force enable LAPACK when Julia's OpenBLAS is available

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -105,6 +105,7 @@ if !libmxnet_detected
     ilp64 = "-DINTERFACE64"
   end
 
+  FORCE_LAPACK = false
   if blas_vendor == :unknown
     info("Julia is built with an unkown blas library ($blas_path).")
     info("Attempting build without reusing the blas library")
@@ -115,6 +116,7 @@ if !libmxnet_detected
     USE_JULIA_BLAS = true
   else
     USE_JULIA_BLAS = true
+    FORCE_LAPACK = true
   end
 
   blas_name = blas_vendor == :openblas64 ? "openblas" : string(blas_vendor)
@@ -163,6 +165,11 @@ if !libmxnet_detected
             if haskey(ENV, "CUDA_HOME")
               `sed -i -s 's/USE_CUDA_PATH = NULL/USE_CUDA_PATH = $(ENV["CUDA_HOME"])/' config.mk`
             end
+          end
+          # Force enable LAPACK build
+          # Julia's OpenBLAS has LAPACK functionality already
+          if FORCE_LAPACK
+            `sed -i -s 's/ADD_CFLAGS =\(.*\)/ADD_CFLAGS =\1 -DMXNET_USE_LAPACK/' config.mk`
           end
         end)
         @build_steps begin


### PR DESCRIPTION
Blocker PR: ~#267~, #271 (travis stuff)

---

I got this warning message before this PR

```c
In file included from src/operator/tensor/./../linalg.h:31:0,                                                          
                 from src/operator/tensor/./la_op_inline.h:27,                                                         
                 from src/operator/tensor/la_op.cc:25:                                                                 
src/operator/tensor/./.././c_lapack_api.h:245:25: note: #pragma message: Warning: lapack usage not enabled, linalg-ope$ators will not be available. Ensure that lapack library is installed and build with USE_LAPACK=1 to get lapack functio$
alities.                                                                                                               
      " functionalities.")                                                                                             
                         ^
```

due to  this silent fallback:
https://github.com/apache/incubator-mxnet/blob/ce20a60b5046bbf184bee0b0845c9c630435ad42/Makefile#L129-L145

The main idea of this PR is appending `-DMXNET_USE_LAPACK` to `ADD_CFLAGS` when Julia's BLAS vender is OpenBLAS; bypassing the silent fallback.
