### PR TITLE
reshape on NDArray not working?

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# v0.3.0 (TBD)
+
+## API Changes
+
+* `reshape` of NDArray share the same interface with Base (#272).
+    * `reshape(NDArray, dim; reverse=false)`
+    * `reshape(NDArray, dim...; reverse=false)`
+    * `Reshape` deprecated.
+
 # v0.2.2 (2017.05.14)
 * Updated supported version of MXNet to 0.9.4.
 * Improved build-system with support for auto-detecting GPU support.

--- a/src/MXNet.jl
+++ b/src/MXNet.jl
@@ -50,6 +50,8 @@ include("visualize.jl")
 
 include("nn-factory.jl")
 
+include("deprecated.jl")
+
 end # mx
 
 end # module MXNet

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+# reshape (#272)
+@deprecate reshape(arr::NDArray; shape=()) reshape(arr, shape)
+@deprecate Reshape(arr::NDArray; shape=()) reshape(arr, shape)

--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -921,6 +921,31 @@ function save(filename::String, data::Dict{Base.Symbol,NDArray})
           filename, length(names), arrays, names)
 end
 
+import Base: reshape
+
+"""
+    reshape(arr::NDArray, dim...; reverse=false)
+    reshape(arr::NDArray, dim; reverse=false)
+"""
+reshape{N}(arr::NDArray, dim::NTuple{N, Integer}; reverse::Bool=false) =
+    _reshape(arr, dim, reverse)
+reshape{N}(arr::NDArray, dim::Vararg{Integer, N}; reverse::Bool=false) =
+    _reshape(arr, dim, reverse)
+
+@inline function _reshape{N}(arr::NDArray, dim::NTuple{N, Integer}, reverse::Bool)
+  op_handle = _get_cached_libmx_op_handle("reshape")
+  n_output = Ref(Cint(0))
+  hdls_ref = Ref{Ptr{MX_handle}}(C_NULL)
+  @mxcall(:MXImperativeInvoke,
+          (MX_handle, Cint, Ptr{MX_handle}, Ref{Cint}, Ref{Ptr{MX_handle}},
+           Cint, char_pp, char_pp),
+          op_handle, 1, [arr.handle], n_output, hdls_ref,
+          2, ["shape", "reverse"], [dump_mx_param(dim), dump_mx_param(!reverse)])
+  #                                                       not a typo  ^^^^^^^^
+  @assert n_output[] == 1
+  NDArray(MX_NDArrayHandle(unsafe_load(hdls_ref[], 1)))
+end
+
 ################################################################################
 # NDArray functions dynamically imported from libmxnet
 ################################################################################
@@ -980,7 +1005,6 @@ Upon calling, the output arguments will be automatically initialized with empty 
 Those functions always return the output arguments. If there is only one output (the typical situation), that
 object (`NDArray`) is returned. Otherwise, a tuple containing all the outputs will be returned.
 """
-
 function _get_ndarray_function_def(name :: String)
   func_name = Symbol(name)
 
@@ -1063,7 +1087,9 @@ function _get_ndarray_function_def(name :: String)
 end
 
 macro _import_ndarray_functions()
-  names = _get_libmx_op_names()
+  black_list = ["reshape"]  # do not import these funcs
+  names = filter(n -> ∉(lowercase(n), black_list), _get_libmx_op_names())
+
   func_exprs = map(names) do name
     op_handle = _get_libmx_op_handle(name)
 
@@ -1073,7 +1099,7 @@ macro _import_ndarray_functions()
     func_name = Symbol(name)
     expr = quote
       # TODO the explicit exclusion of take will no longer be necessary when it is removed from Base
-      $((isdefined(Base, func_name) && func_name ≠ :take)? :(import Base.$func_name) : :())
+      $((isdefined(Base, func_name) && func_name ≠ :take) ? :(import Base.$func_name) : :())
       $func_def
       @doc $desc ->
       $func_def2

--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -109,7 +109,7 @@ function test_plus()
   scalar_large = 1e8
   @test reldiff(t4 + scalar_small, copy(a4 .+ scalar_small)) < thresh
   @test reldiff(t4 + scalar_large, copy(a4 .+ scalar_large)) < thresh
-  
+
   t5 = zeros(Float64, dims)
   a5 = copy(t5, mx.cpu())
   scalar_small = 1e-8
@@ -160,7 +160,7 @@ function test_minus()
   scalar_large = 1e8
   @test reldiff(t4 - scalar_small, copy(a4 .- scalar_small)) < thresh
   @test reldiff(t4 - scalar_large, copy(a4 .- scalar_large)) < thresh
-  
+
   t5 = zeros(Float64, dims)
   a5 = copy(t5, mx.cpu())
   scalar_small = 1e-8
@@ -204,7 +204,7 @@ function test_mul()
   scalar_large = 1e8
   @test reldiff(t4 * scalar_small, copy(a4 .* scalar_small)) < thresh
   @test reldiff(t4 * scalar_large, copy(a4 .* scalar_large)) < thresh
-  
+
   t5, a5 = rand_tensors(Float64, dims)
   scalar_small = 1e-8
   scalar_large = 1e8
@@ -245,7 +245,7 @@ function test_div()
   scalar_large = 1e8
   @test reldiff(t4 / scalar_small, copy(a4 ./ scalar_small)) < thresh
   @test reldiff(t4 / scalar_large, copy(a4 ./ scalar_large)) < thresh
-  
+
   t5, a5 = rand_tensors(Float64, dims)
   scalar_small = 1e-8
   scalar_large = 1e8
@@ -382,6 +382,28 @@ function test_eltype()
   end
 end
 
+function test_reshape()
+    info("NDArray::reshape")
+    A = rand(2, 3, 4)
+
+    B = reshape(mx.NDArray(A), 4, 3, 2)
+    @test size(B) == (4, 3, 2)
+    @test copy(B)[3, 1, 1] == A[1, 2, 1]
+
+    C = reshape(mx.NDArray(A), (4, 3, 2))
+    @test size(C) == (4, 3, 2)
+    @test copy(C)[3, 1, 1] == A[1, 2, 1]
+
+    info("NDArray::reshape::reverse")
+    A = mx.zeros(10, 5, 4)
+
+    B = reshape(A, -1, 0)
+    @test size(B) == (40, 5)
+
+    C = reshape(A, -1, 0, reverse=true)
+    @test size(C) == (50, 4)
+end
+
 function test_kwargs()
   info("NDArray::kwargs")
   dims1 = (2,3,4)
@@ -412,6 +434,7 @@ end
   test_eltype()
   test_nd_as_jl()
   test_dot()
+  test_reshape()
   test_kwargs()
 end
 


### PR DESCRIPTION
```julia
julia> x = mx.zeros(3, 4)

julia> y = mx.reshape(x, shape=(4, 3)) 
mx.NDArray{Float32}(3, 4)         

julia> size(y)
(3, 4)

julia> copy(y) 
3×4 Array{Float32,2}:   
 0.0  0.0  0.0  0.0 
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
```