### PR TITLE
sym-node: support `print` for debugging

### DIFF
--- a/src/symbolic-node.jl
+++ b/src/symbolic-node.jl
@@ -220,6 +220,51 @@ function get_name(self :: mx.SymbolicNode)
     return Symbol(unsafe_string(name[]))
 end
 
+import Base: print
+
+function print(io :: IO, sym :: SymbolicNode)
+  out = Ref{mx.char_p}(C_NULL)
+  @mx.mxcall(:MXSymbolPrint, (mx.MX_SymbolHandle, Ref{mx.char_p}), sym.handle, out)
+  print(io, unsafe_string(out[]))
+end
+
+print(sym :: SymbolicNode) = print(STDOUT, sym)
+
+"""
+    print([io :: IO], sym :: SymbolicNode)
+
+Print the content of symbol, used for debug.
+
+```julia
+julia> layer = @mx.chain mx.Variable(:data)           =>
+         mx.FullyConnected(name=:fc1, num_hidden=128) =>
+         mx.Activation(name=:relu1, act_type=:relu)
+MXNet.mx.SymbolicNode(MXNet.mx.MX_SymbolHandle(Ptr{Void} @0x000055b29b9c3520))
+
+julia> print(layer)
+Symbol Outputs:
+        output[0]=relu1(0)
+Variable:data
+Variable:fc1_weight
+Variable:fc1_bias
+--------------------
+Op:FullyConnected, Name=fc1
+Inputs:
+        arg[0]=data(0) version=0
+        arg[1]=fc1_weight(0) version=0
+        arg[2]=fc1_bias(0) version=0
+Attrs:
+        num_hidden=128
+--------------------
+Op:Activation, Name=relu1
+Inputs:
+        arg[0]=fc1(0)
+Attrs:
+        act_type=relu
+```
+"""
+print
+
 """
     grad(self :: SymbolicNode, wrt :: Vector{SymbolicNode})
 

--- a/test/unittest/symbolic-node.jl
+++ b/test/unittest/symbolic-node.jl
@@ -136,6 +136,13 @@ function test_dot()
   @test reldiff(ret, 2*ones(100, 200)) < 1e-6
 end
 
+function test_print()
+  info("SymbolicNode::print")
+  io = IOBuffer()
+  print(io, mx.Variable(:x))
+  @test !isempty(String(take!(io)))
+end
+
 function test_misc()
   info("SymbolicNode::Miscellaneous")
   # Test for #189
@@ -158,6 +165,7 @@ end
   test_attrs()
   test_functions()
   test_dot()
+  test_print()
   test_misc()
 end
 


### PR DESCRIPTION
Ref: https://github.com/apache/incubator-mxnet/blob/470b56437290b33fef51b067c96fdce08cefa584/include/mxnet/c_api.h#L933

example: 
```julia
julia> print(mx.dot(mx.Variable(:x), mx.Variable(:y)))
Symbol Outputs:
        output[0]=dot4(0)
Variable:y
Variable:x
--------------------
Op:dot, Name=dot4
Inputs:
        arg[0]=y(0) version=0
        arg[1]=x(0) version=0
```