### PR TITLE
deepcopy on NDArray

### DIFF
--- a/src/ndarray.jl
+++ b/src/ndarray.jl
@@ -403,7 +403,8 @@ function getindex(arr :: NDArray, idx::UnitRange{Int})
   slice(arr, idx)
 end
 
-import Base: copy!, copy, convert
+import Base: copy!, copy, convert, deepcopy
+
 """
     copy!(dst :: Union{NDArray, Array}, src :: Union{NDArray, Array})
 
@@ -483,6 +484,18 @@ Convert an `NDArray` into a Julia `Array` of specific type. Data will be copied.
 """
 function convert{T<:Real}(t::Type{Array{T}}, arr :: NDArray)
   convert(t, copy(arr))
+end
+
+"""
+    deepcopy(arr::NDArray)
+
+Get a deep copy of the data blob in the form of an NDArray of default storage
+type. This function blocks. Do not use it in performance critical code.
+"""
+function deepcopy(arr::NDArray)
+  out_ref = Ref{MX_handle}(C_NULL)
+  @mxcall(:MXNDArrayGetDataNDArray, (MX_handle, Ref{MX_handle}), arr, out_ref)
+  NDArray(MX_NDArrayHandle(out_ref[]))
 end
 
 """

--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -31,6 +31,15 @@ function test_copy()
   @test reldiff(tensor, tensor2) < 1e-6
 end
 
+function test_deepcopy()
+  info("NDArray::deepcopy")
+
+  x = mx.zeros(2, 5)
+  y = deepcopy(x)
+  x[:] = 42
+  @test copy(x) != copy(y)
+end
+
 function test_assign()
   dims    = rand_dims()
   tensor  = rand(mx.MX_float, dims)


### PR DESCRIPTION
https://github.com/apache/incubator-mxnet/blob/470b56437290b33fef51b067c96fdce08cefa584/include/mxnet/c_api.h#L516

seems we have it on `SymbolicNode` already, but `NDArray` not.