### PR TITLE
ndarray: pretty printing

### DIFF
--- a/test/unittest/ndarray.jl
+++ b/test/unittest/ndarray.jl
@@ -425,6 +425,16 @@ function test_kwargs()
   @test all(copy(tx) .== tA)
 end
 
+function test_show()
+  let str = sprint(show, mx.NDArray([1 2 3 4]))
+    @test contains(str, "1x4")
+    @test contains(str, "mx.NDArray")
+    @test contains(str, "Int64")
+    @test contains(str, "CPU")
+    @test match(r"1\s+2\s+3\s+4", str) != nothing
+  end
+end
+
 ################################################################################
 # Run tests
 ################################################################################
@@ -445,6 +455,7 @@ end
   test_dot()
   test_reshape()
   test_kwargs()
+  test_show()
 end
 
 end


### PR DESCRIPTION
Leverage `Base.showarray`.

e.g.
```julia
julia> mx.rand(0, 1, (5, 20))
5x20 mx.NDArray{Float32} @ CPU0:
 0.628982    0.425452  0.952792  …  0.785153  0.181631
 5.53504f-5  0.798047  0.45613      0.984329  0.0639553
 0.872651    0.885338  0.687488     0.28173   0.512393
 0.31186     0.185636  0.483409     0.703495  0.485628
 0.273542    0.679879  0.215508     0.58641   0.580447
```